### PR TITLE
Configured Travis to avoid double builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,20 @@ node_js:
   - 8.16
   - 10
 
+# Build only commits on master and release tags preventing double builds for PRs
+# See https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests
+branches:
+  only:
+    - master
+    - /v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
+
 cache: npm
 
-before_script: npm run lint:test
+script:
+  - npm run lint:test
+  - npm run test:report
 
-script: npm run test:report
+# TODO: Notifications on failure ?
 
-# TODO: Notifications
 # TODO: add coveralls
 # TODO: Add npm publishing on tags

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # graphdb-javascript-driver (GRAPHDBJS)
 
+[![Build Status](https://travis-ci.com/Ontotext-AD/graphdb.js.svg?branch=master)](https://travis-ci.com/Ontotext-AD/graphdb.js)
+
 A GraphDB and RDF4J data access library written in JavaScript to be used in Node.js.  
 
 ## Installation


### PR DESCRIPTION
By default, Travis triggers two builds: one for the pushed branch and
one for the updated PR. Configured to build only the master branch and
release tags.

Added Travis build status image (build badge) in the readme file.