### PR TITLE
Make ContentParser to accept a configuration object

### DIFF
--- a/src/parser/content-parser.js
+++ b/src/parser/content-parser.js
@@ -7,18 +7,28 @@
  */
 class ContentParser {
   /**
-   * @param {boolean} isDefault if the implementation is configured as default.
+   * @param {Object} config is an object containing the parser configuration.
    */
-  constructor(isDefault) {
-    this.default = isDefault !== undefined ? isDefault : false;
+  constructor(config) {
+    this.configureParser(config);
   }
 
   /**
-   * @return {boolean} <code>true</code> if current implementation is set as
-   * default and <code>false</code> otherwise.
+   * Configure the parser instance.
+   *
+   * @private
+   * @param {Object} config
    */
-  isDefault() {
-    return this.default;
+  configureParser(config = {}) {
+    this.config = config;
+  }
+
+  /**
+   * @return {Object} config is the passed during the initialization parser
+   * config object.
+   */
+  getConfig() {
+    return this.config;
   }
 
   /**

--- a/src/parser/n-quads-parser.js
+++ b/src/parser/n-quads-parser.js
@@ -13,8 +13,8 @@ class NQuadsParser extends ContentParser {
   /**
    * @inheritDoc
    */
-  constructor(isDefault) {
-    super(isDefault);
+  constructor(config) {
+    super(config);
 
     this.parser = new Parser({
       format: this.getSupportedType()

--- a/src/parser/n-triples-parser.js
+++ b/src/parser/n-triples-parser.js
@@ -13,8 +13,8 @@ class NTriplesParser extends ContentParser {
   /**
    * @inheritDoc
    */
-  constructor(isDefault) {
-    super(isDefault);
+  constructor(config) {
+    super(config);
 
     this.parser = new Parser({
       // Not using the supported type as it is text/plain which is the default

--- a/src/parser/n3-parser.js
+++ b/src/parser/n3-parser.js
@@ -13,8 +13,8 @@ class N3Parser extends ContentParser {
   /**
    * @inheritDoc
    */
-  constructor(isDefault) {
-    super(isDefault);
+  constructor(config) {
+    super(config);
 
     this.parser = new Parser({
       format: this.getSupportedType()

--- a/src/parser/sparql-json-result-parser.js
+++ b/src/parser/sparql-json-result-parser.js
@@ -21,8 +21,8 @@ class SparqlJsonResultParser extends ContentParser {
   /**
    * @inheritDoc
    */
-  constructor(isDefault) {
-    super(isDefault);
+  constructor(config) {
+    super(config);
 
     this.parser = new SparqlJsonParser({
       dataFactory: DataFactory

--- a/src/parser/sparql-xml-result-parser.js
+++ b/src/parser/sparql-xml-result-parser.js
@@ -21,8 +21,8 @@ class SparqlXmlResultParser extends ContentParser {
   /**
    * @inheritDoc
    */
-  constructor(isDefault) {
-    super(isDefault);
+  constructor(config) {
+    super(config);
 
     this.parser = new SparqlXmlParser({
       dataFactory: DataFactory

--- a/src/parser/trig-parser.js
+++ b/src/parser/trig-parser.js
@@ -13,8 +13,8 @@ class TriGParser extends ContentParser {
   /**
    * @inheritDoc
    */
-  constructor(isDefault) {
-    super(isDefault);
+  constructor(config) {
+    super(config);
 
     this.parser = new Parser({
       format: this.getSupportedType()

--- a/src/parser/turtle-parser.js
+++ b/src/parser/turtle-parser.js
@@ -13,8 +13,8 @@ class TurtleParser extends ContentParser {
   /**
    * @inheritDoc
    */
-  constructor(isDefault) {
-    super(isDefault);
+  constructor(config) {
+    super(config);
 
     this.parser = new Parser({
       format: this.getSupportedType()

--- a/test/parser/content-parser.spec.js
+++ b/test/parser/content-parser.spec.js
@@ -17,17 +17,12 @@ describe('ContentParser', () => {
     }).toThrow(Error('Method #parse(content) must be implemented!'));
   });
 
-  test('should initialize #isDefault to false by default if not provided', () => {
-    const parser = new RdfAsXmlParser();
-    expect(parser.isDefault()).toBeFalsy();
-  });
+  test('should store provided with the constructor configuration', () => {
+    let parserInstance = new RdfAsXmlParser();
+    expect(parserInstance.getConfig()).toEqual({});
 
-  test('should initialize #isDefault to provided value', () => {
-    let parser = new RdfAsXmlParser(false);
-    expect(parser.isDefault()).toBeFalsy();
-
-    parser = new RdfAsXmlParser(true);
-    expect(parser.isDefault()).toBeTruthy();
+    parserInstance = new RdfAsXmlParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should instantiate a valid implementation properly', () => {

--- a/test/parser/n-quads-parser.spec.js
+++ b/test/parser/n-quads-parser.spec.js
@@ -6,11 +6,12 @@ describe('NQuadsParser', () => {
     expect(new NQuadsParser().parser).toBeDefined();
   });
 
-  test('should set isDefault if provided to constructor', () => {
+  test('should store provided with the constructor configuration', () => {
     let parserInstance = new NQuadsParser();
-    expect(parserInstance.isDefault()).toBeFalsy();
-    parserInstance = new NQuadsParser(true);
-    expect(parserInstance.isDefault()).toBeTruthy();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new NQuadsParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should return supported type', () => {

--- a/test/parser/n-triples-parser.spec.js
+++ b/test/parser/n-triples-parser.spec.js
@@ -6,11 +6,12 @@ describe('NTriplesParser', () => {
     expect(new NTriplesParser().parser).toBeDefined();
   });
 
-  test('should set isDefault if provided to constructor', () => {
+  test('should store provided with the constructor configuration', () => {
     let parserInstance = new NTriplesParser();
-    expect(parserInstance.isDefault()).toBeFalsy();
-    parserInstance = new NTriplesParser(true);
-    expect(parserInstance.isDefault()).toBeTruthy();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new NTriplesParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should return supported type', () => {

--- a/test/parser/n3-parser.spec.js
+++ b/test/parser/n3-parser.spec.js
@@ -6,11 +6,12 @@ describe('N3Parser', () => {
     expect(new N3Parser().parser).toBeDefined();
   });
 
-  test('should set isDefault if provided to constructor', () => {
+  test('should store provided with the constructor configuration', () => {
     let parserInstance = new N3Parser();
-    expect(parserInstance.isDefault()).toBeFalsy();
-    parserInstance = new N3Parser(true);
-    expect(parserInstance.isDefault()).toBeTruthy();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new N3Parser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should return supported type', () => {

--- a/test/parser/sparql-json-result-parser.spec.js
+++ b/test/parser/sparql-json-result-parser.spec.js
@@ -12,11 +12,12 @@ describe('SparqlJsonResultParser', () => {
     expect(new SparqlJsonResultParser().parser.dataFactory.internal).toBeDefined();
   });
 
-  test('should set isDefault if provided to constructor', () => {
+  test('should store provided with the constructor configuration', () => {
     let parserInstance = new SparqlJsonResultParser();
-    expect(parserInstance.isDefault()).toBeFalsy();
-    parserInstance = new SparqlJsonResultParser(true);
-    expect(parserInstance.isDefault()).toBeTruthy();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new SparqlJsonResultParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should return supported type', () => {

--- a/test/parser/sparql-xml-result-parser.spec.js
+++ b/test/parser/sparql-xml-result-parser.spec.js
@@ -12,11 +12,12 @@ describe('SparqlXmlResultParser', () => {
     expect(new SparqlXmlResultParser().parser.dataFactory.internal).toBeDefined();
   });
 
-  test('should set isDefault if provided to constructor', () => {
+  test('should store provided with the constructor configuration', () => {
     let parserInstance = new SparqlXmlResultParser();
-    expect(parserInstance.isDefault()).toBeFalsy();
-    parserInstance = new SparqlXmlResultParser(true);
-    expect(parserInstance.isDefault()).toBeTruthy();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new SparqlXmlResultParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should return supported type', () => {

--- a/test/parser/trig-parser.spec.js
+++ b/test/parser/trig-parser.spec.js
@@ -6,11 +6,12 @@ describe('TriGParser', () => {
     expect(new TriGParser().parser).toBeDefined();
   });
 
-  test('should set isDefault if provided to constructor', () => {
+  test('should store provided with the constructor configuration', () => {
     let parserInstance = new TriGParser();
-    expect(parserInstance.isDefault()).toBeFalsy();
-    parserInstance = new TriGParser(true);
-    expect(parserInstance.isDefault()).toBeTruthy();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new TriGParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should return supported type', () => {

--- a/test/parser/turtle-parser.spec.js
+++ b/test/parser/turtle-parser.spec.js
@@ -6,11 +6,12 @@ describe('TurtleParser', () => {
     expect(new TurtleParser().parser).toBeDefined();
   });
 
-  test('should set isDefault if provided to constructor', () => {
+  test('should store provided with the constructor configuration', () => {
     let parserInstance = new TurtleParser();
-    expect(parserInstance.isDefault()).toBeFalsy();
-    parserInstance = new TurtleParser(true);
-    expect(parserInstance.isDefault()).toBeTruthy();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new TurtleParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
   });
 
   test('should return supported type', () => {


### PR DESCRIPTION
Currently parser wrappers accept a single boolean argument but it would be better to have an object as configuration because some parsers might allow additional configuration which in current implementation is not possible to be provided externaly. For example N3 parsers allow a DataFactory object to be passed to their constructor.

Refactored the ContentParser to accept an object as configuration.
Remove `isDefault` parameter which turns out to be redundant.
Updated tests.

Ticket: GDB-3548