### PR TITLE
Add isStreaming property to parsers

### DIFF
--- a/src/parser/content-parser.js
+++ b/src/parser/content-parser.js
@@ -32,6 +32,18 @@ class ContentParser {
   }
 
   /**
+   * If implemented by successors, this must return boolean <code>true</code>
+   * when the wrapped parser supports stream reading by default or
+   * <code>false</code> otherwise.
+   *
+   * @abstract
+   * @return {boolean} if the parser supports streaming by default
+   */
+  isStreaming() {
+    return false;
+  }
+
+  /**
    * Implementations should delegate the actual parsing to underlying parser
    * library or to a custom implementation.
    *

--- a/src/parser/sparql-json-result-parser.js
+++ b/src/parser/sparql-json-result-parser.js
@@ -61,6 +61,13 @@ class SparqlJsonResultParser extends ContentParser {
   getSupportedType() {
     return RDFMimeType.SPARQL_RESULTS_JSON;
   }
+
+  /**
+   * @inheritDoc
+   */
+  isStreaming() {
+    return true;
+  }
 }
 
 module.exports = SparqlJsonResultParser;

--- a/src/parser/sparql-xml-result-parser.js
+++ b/src/parser/sparql-xml-result-parser.js
@@ -61,6 +61,13 @@ class SparqlXmlResultParser extends ContentParser {
   getSupportedType() {
     return RDFMimeType.SPARQL_RESULTS_XML;
   }
+
+  /**
+   * @inheritDoc
+   */
+  isStreaming() {
+    return true;
+  }
 }
 
 module.exports = SparqlXmlResultParser;

--- a/src/repository/base-repository-client.js
+++ b/src/repository/base-repository-client.js
@@ -92,6 +92,16 @@ class BaseRepositoryClient {
   }
 
   /**
+   * Obtain a parser instance by type.
+   *
+   * @param {string} responseType
+   * @return {ContentParser}
+   */
+  getParser(responseType) {
+    return this.parserRegistry.get(responseType);
+  }
+
+  /**
    * Parses provided content with registered parser if there is one. Otherwise
    * returns the content untouched. If <code>contentType</code> is provided it
    * should be an instance of {@link RDFMimeType} enum and is used as a key

--- a/src/repository/rdf-repository-client.js
+++ b/src/repository/rdf-repository-client.js
@@ -223,7 +223,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    *      to provided response type.
    */
   get(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const reqConfig = new HttpRequestConfigBuilder()
       .setParams({
         subj: TermConverter.toNTripleValue(payload.getSubject()),
         pred: TermConverter.toNTripleValue(payload.getPredicate()),
@@ -231,10 +231,14 @@ class RDFRepositoryClient extends BaseRepositoryClient {
         context: TermConverter.toNTripleValues(payload.getContext()),
         infer: payload.getInference()
       })
-      .addAcceptHeader(payload.getResponseType())
-      .get();
+      .addAcceptHeader(payload.getResponseType());
 
-    return this.execute((http) => http.get(PATH_STATEMENTS, requestConfig))
+    const parser = this.getParser(payload.getResponseType());
+    if (parser && parser.isStreaming()) {
+      reqConfig.setResponseType('stream');
+    }
+
+    return this.execute((http) => http.get(PATH_STATEMENTS, reqConfig.get()))
       .then((response) => {
         this.logger.debug(this.getLogPayload(response, {
           subject: payload.getSubject(),

--- a/src/transaction/transactional-repository-client.js
+++ b/src/transaction/transactional-repository-client.js
@@ -101,10 +101,14 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         context: TermConverter.toNTripleValues(payload.getContext()),
         infer: payload.getInference()
       })
-      .addAcceptHeader(payload.getResponseType())
-      .get();
+      .addAcceptHeader(payload.getResponseType());
 
-    return this.execute((http) => http.put('', null, requestConfig))
+    const parser = this.getParser(payload.getResponseType());
+    if (parser && parser.isStreaming()) {
+      requestConfig.setResponseType('stream');
+    }
+
+    return this.execute((http) => http.put('', null, requestConfig.get()))
       .then((response) => {
         this.logger.debug(this.getLogPayload(response, {
           subject: payload.getSubject(),

--- a/test/parser/content-parser.spec.js
+++ b/test/parser/content-parser.spec.js
@@ -29,4 +29,8 @@ describe('ContentParser', () => {
     const parser = new RdfAsXmlParser();
     expect(parser).toBeDefined();
   });
+
+  test('should not be streaming parser by default', () => {
+    expect(new RdfAsXmlParser().isStreaming()).toBeFalsy();
+  });
 });

--- a/test/parser/n-quads-parser.spec.js
+++ b/test/parser/n-quads-parser.spec.js
@@ -25,4 +25,8 @@ describe('NQuadsParser', () => {
     expect(parserInstance.parser.parse).toHaveBeenCalledTimes(1);
     expect(parserInstance.parser.parse).toHaveBeenCalledWith('content');
   });
+
+  test('should not be a streaming parser', () => {
+    expect(new NQuadsParser().isStreaming()).toBeFalsy();
+  });
 });

--- a/test/parser/n-triples-parser.spec.js
+++ b/test/parser/n-triples-parser.spec.js
@@ -25,4 +25,8 @@ describe('NTriplesParser', () => {
     expect(parserInstance.parser.parse).toHaveBeenCalledTimes(1);
     expect(parserInstance.parser.parse).toHaveBeenCalledWith('content');
   });
+
+  test('should not be a streaming parser', () => {
+    expect(new NTriplesParser().isStreaming()).toBeFalsy();
+  });
 });

--- a/test/parser/n3-parser.spec.js
+++ b/test/parser/n3-parser.spec.js
@@ -25,4 +25,8 @@ describe('N3Parser', () => {
     expect(parserInstance.parser.parse).toHaveBeenCalledTimes(1);
     expect(parserInstance.parser.parse).toHaveBeenCalledWith('content');
   });
+
+  test('should not be a streaming parser', () => {
+    expect(new N3Parser().isStreaming()).toBeFalsy();
+  });
 });

--- a/test/parser/sparql-json-result-parser.spec.js
+++ b/test/parser/sparql-json-result-parser.spec.js
@@ -39,4 +39,8 @@ describe('SparqlJsonResultParser', () => {
     expect(parserInstance.parser.parseJsonBooleanStream).toHaveBeenCalledTimes(1);
     expect(parserInstance.parser.parseJsonBooleanStream).toHaveBeenCalledWith('content');
   });
+
+  test('should be a streaming parser', () => {
+    expect(new SparqlJsonResultParser().isStreaming()).toBeTruthy();
+  });
 });

--- a/test/parser/sparql-xml-result-parser.spec.js
+++ b/test/parser/sparql-xml-result-parser.spec.js
@@ -39,4 +39,8 @@ describe('SparqlXmlResultParser', () => {
     expect(parserInstance.parser.parseXmlBooleanStream).toHaveBeenCalledTimes(1);
     expect(parserInstance.parser.parseXmlBooleanStream).toHaveBeenCalledWith('content');
   });
+
+  test('should be a streaming parser', () => {
+    expect(new SparqlXmlResultParser().isStreaming()).toBeTruthy();
+  });
 });

--- a/test/parser/trig-parser.spec.js
+++ b/test/parser/trig-parser.spec.js
@@ -25,4 +25,8 @@ describe('TriGParser', () => {
     expect(parserInstance.parser.parse).toHaveBeenCalledTimes(1);
     expect(parserInstance.parser.parse).toHaveBeenCalledWith('content');
   });
+
+  test('should not be a streaming parser', () => {
+    expect(new TriGParser().isStreaming()).toBeFalsy();
+  });
 });

--- a/test/parser/turtle-parser.spec.js
+++ b/test/parser/turtle-parser.spec.js
@@ -25,4 +25,8 @@ describe('TurtleParser', () => {
     expect(parserInstance.parser.parse).toHaveBeenCalledTimes(1);
     expect(parserInstance.parser.parse).toHaveBeenCalledWith('content');
   });
+
+  test('should not be a streaming parser', () => {
+    expect(new TurtleParser().isStreaming()).toBeFalsy();
+  });
 });


### PR DESCRIPTION
Some of the parsers are streaming by default and others aren't. That's why we need a way to distinguish them in order to be able to configure the http request properly before sending it. For example if there is a configured parser for given content type and its a streaming one, then the http request must be configured with `responseType=stream` in order to have a response formatted properly and parser to be able to consume it.

Updated tests

Ticket: GDB-3548