### PR TITLE
Implement parser wrapper for jsonld

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2691,6 +2691,14 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -4377,7 +4385,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -4734,8 +4741,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -4781,6 +4787,15 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -5678,6 +5693,26 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonld-context-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-1.2.0.tgz",
+      "integrity": "sha512-9ZKnRg2Y/GkFefDVuH44wNTO3V1HefUB4+shDdRhF9Ar0xiGceD1GMON99QDp/r0pYqFb4CCT5J7WCzT5RWJoQ==",
+      "requires": {
+        "isomorphic-fetch": "^2.2.1",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "jsonld-streaming-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-1.1.0.tgz",
+      "integrity": "sha512-DvK7vm02wTsL+YjK1QmGlMeXMdW03/kB7Mx9Nw8XnN55ALZDTWdMJxwlBfWnXRE17mQJdUPC6cOQKzwzRtvO/w==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^2.0.1",
+        "jsonld-context-parser": "^1.1.3",
+        "jsonparse": "^1.3.1"
+      }
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -6226,6 +6261,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7140,6 +7184,11 @@
         }
       }
     },
+    "relative-to-absolute-iri": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.2.tgz",
+      "integrity": "sha512-2tAsyCpb/ozT6w8BSaz//u7iRIW621FsMbC8el4VqzvtuntevEFfWNM/Wr9ubodzGa9OwBNwOHERRKqw9toKOA=="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -7390,8 +7439,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -8652,6 +8700,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -84,11 +84,12 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
+    "jsonld-streaming-parser": "^1.1.0",
     "n3": "^1.0.5",
+    "pino": "^5.12.4",
     "qs": "^6.7.0",
     "sparqljson-parse": "^1.5.0",
     "sparqlxml-parse": "^1.2.1",
-    "pino": "^5.12.4",
     "uuid": "^3.3.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ module.exports = {
     NTriplesParser: require('./parser/n-triples-parser'),
     TriGParser: require('./parser/trig-parser'),
     TurtleParser: require('./parser/turtle-parser'),
+    JsonLDParser: require('./parser/jsonld-parser'),
     SparqlJsonResultParser: require('./parser/sparql-json-result-parser'),
     SparqlXmlResultParser: require('./parser/sparql-xml-result-parser')
   },

--- a/src/parser/jsonld-parser.js
+++ b/src/parser/jsonld-parser.js
@@ -1,0 +1,44 @@
+const ContentParser = require('../parser/content-parser');
+const RDFMimeType = require('../http/rdf-mime-type');
+const JsonLdParser = require('jsonld-streaming-parser').JsonLdParser;
+
+/**
+ * Parse jsonld data to triple/quads
+ *
+ * @class
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class JsonLDParser extends ContentParser {
+  /**
+   * @inheritDoc
+   */
+  constructor(config) {
+    super(config);
+
+    this.parser = new JsonLdParser(this.config);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  parse(content, config) {
+    return this.parser.import(content);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getSupportedType() {
+    return RDFMimeType.JSON_LD;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  isStreaming() {
+    return true;
+  }
+}
+
+module.exports = JsonLDParser;

--- a/test/parser/jsonld-parser.spec.js
+++ b/test/parser/jsonld-parser.spec.js
@@ -1,0 +1,33 @@
+const JsonLDParser = require('parser/jsonld-parser');
+const RDFMimeType = require('http/rdf-mime-type');
+
+describe('JsonLDParser', () => {
+  test('should create instance of underlying parser and store it as a member', () => {
+    expect(new JsonLDParser().parser).toBeDefined();
+  });
+
+  test('should store provided with the constructor configuration', () => {
+    let parserInstance = new JsonLDParser();
+    expect(parserInstance.getConfig()).toEqual({});
+
+    parserInstance = new JsonLDParser({param: true});
+    expect(parserInstance.getConfig()).toEqual({param: true});
+  });
+
+  test('should return supported type', () => {
+    expect(new JsonLDParser().getSupportedType()).toEqual(RDFMimeType.JSON_LD);
+  });
+
+  test('should invoke underlying parser for text stream result parsing', () => {
+    const parserInstance = new JsonLDParser();
+    parserInstance.parser.import = jest.fn();
+    parserInstance.parse('content');
+    expect(parserInstance.parser.import).toHaveBeenCalledTimes(1);
+    expect(parserInstance.parser.import).toHaveBeenCalledWith('content');
+  });
+
+  test('should be a streaming parser', () => {
+    const parserInstance = new JsonLDParser();
+    expect(parserInstance.isStreaming()).toBeTruthy();
+  });
+});

--- a/test/repository/data/read-statements-jsonld.txt
+++ b/test/repository/data/read-statements-jsonld.txt
@@ -1,0 +1,73 @@
+[ {
+  "@id" : "http://eunis.eea.europa.eu/countries/NO",
+  "@type" : [ "http://eunis.eea.europa.eu/rdf/schema.rdf#Country" ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#areaName" : [ {
+    "@value" : "Norge"
+  }, {
+    "@language" : "en",
+    "@value" : "Norway"
+  }, {
+    "@language" : "fr",
+    "@value" : "Norvège"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#areucd" : [ {
+    "@value" : "NO"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#capital" : [ {
+    "@value" : "Oslo"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#eunisAreaCode" : [ {
+    "@value" : "NO"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#hasCountryBioGeoRegion" : [ {
+    "@id" : "http://eunis.eea.europa.eu/countrybiogeo/NO:AL"
+  }, {
+    "@id" : "http://eunis.eea.europa.eu/countrybiogeo/NO:AR"
+  }, {
+    "@id" : "http://eunis.eea.europa.eu/countrybiogeo/NO:AT"
+  }, {
+    "@id" : "http://eunis.eea.europa.eu/countrybiogeo/NO:BO"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#isoCode2" : [ {
+    "@value" : "NO"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#isoCode3" : [ {
+    "@value" : "NOR"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#iso_2_wcmc" : [ {
+    "@value" : "NO"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#iso_3_wcmc" : [ {
+    "@value" : "NOR"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#iso_3_wcmc_parent" : [ {
+    "@value" : "NOR"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#iso_n" : [ {
+    "@type" : "http://www.w3.org/2001/XMLSchema#int",
+    "@value" : "578"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#population" : [ {
+    "@type" : "http://www.w3.org/2001/XMLSchema#integer",
+    "@value" : "4920305"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#selection" : [ {
+    "@type" : "http://www.w3.org/2001/XMLSchema#integer",
+    "@value" : "1"
+  } ],
+  "http://eunis.eea.europa.eu/rdf/schema.rdf#surface" : [ {
+    "@type" : "http://www.w3.org/2001/XMLSchema#integer",
+    "@value" : "323895"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@value" : "Norway"
+  } ],
+  "http://www.w3.org/2002/07/owl#sameAs" : [ {
+    "@id" : "http://rdfdata.eionet.europa.eu/eea/countries/NO"
+  }, {
+    "@id" : "http://dd.eionet.europa.eu/vocabulary/common/countries/NO"
+  } ],
+  "http://www.w3.org/2004/02/skos/core#notation" : [ {
+    "@value" : "NO"
+  } ]
+} ]

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,7 +5,7 @@ function loadFile(relativePath) {
   return fs.readFileSync(path.resolve(__dirname, relativePath), 'utf8');
 }
 
-function readStream(stream) {
+function readStream(stream, isObjectsStream) {
   return new Promise((resolve, reject) => {
     const chunks = [];
 
@@ -16,9 +16,17 @@ function readStream(stream) {
     stream.on('error', reject);
 
     stream.on('end', () => {
-      resolve(Buffer.concat(chunks).toString().trim());
+      if (isObjectsStream) {
+        resolve(chunks);
+      } else {
+        resolve(Buffer.concat(chunks).toString().trim());
+      }
     });
   });
 }
 
-module.exports = {loadFile, readStream};
+function readObjectsStream(stream) {
+  return readStream(stream, true);
+}
+
+module.exports = {loadFile, readStream, readObjectsStream};


### PR DESCRIPTION
The wrapper uses [this](https://github.com/rubensworks/jsonld-streaming-parser.js) jsonld parser. The parser consumes data as a stream and emits rdfjs data model objects.
Implemented tests.
Extended test utils with `readObjectsStream` function which doesn't try to concat and stringify the streamed content as it's expected to contain js objects instead of plain text.

Ticket: GDB-3333