### PR TITLE
Reducing code duplication/complexity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 
 node_js:
-  - 8.16
+  - 8
   - 10
+  - 12
 
 # Build only commits on master and release tags preventing double builds for PRs
 # See https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests
@@ -14,10 +15,8 @@ branches:
 cache: npm
 
 script:
+  - npm run lint
   - npm run lint:test
   - npm run test:report
 
-# TODO: Notifications on failure ?
-
-# TODO: add coveralls
 # TODO: Add npm publishing on tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -1928,32 +1928,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "dev": true,
-      "requires": {
-        "callsites": "^2.0.0"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        }
-      }
-    },
-    "caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "dev": true,
-      "requires": {
-        "caller-callsite": "^2.0.0"
-      }
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2290,41 +2264,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
-      "dev": true,
-      "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
-        "parse-json": "^4.0.0"
-      },
-      "dependencies": {
-        "import-fresh": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "dev": true,
-          "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        }
-      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -4036,12 +3975,6 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true
-    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -4340,47 +4273,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "husky": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-1.3.1.tgz",
-      "integrity": "sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "^5.0.7",
-        "execa": "^1.0.0",
-        "find-up": "^3.0.0",
-        "get-stdin": "^6.0.0",
-        "is-ci": "^2.0.0",
-        "pkg-dir": "^3.0.0",
-        "please-upgrade-node": "^3.1.1",
-        "read-pkg": "^4.0.1",
-        "run-node": "^1.0.0",
-        "slash": "^2.0.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-          "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
-          "dev": true,
-          "requires": {
-            "normalize-package-data": "^2.3.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0"
-          }
-        }
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4627,12 +4519,6 @@
           "dev": true
         }
       }
-    },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -5836,12 +5722,6 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -6812,15 +6692,6 @@
         "find-up": "^3.0.0"
       }
     },
-    "please-upgrade-node": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
-      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
-      "dev": true,
-      "requires": {
-        "semver-compare": "^1.0.0"
-      }
-    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -7390,12 +7261,6 @@
         "is-promise": "^2.1.0"
       }
     },
-    "run-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
-      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
-      "dev": true
-    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -7502,12 +7367,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
-    },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -59,11 +59,6 @@
     "doc": "jsdoc -c jsdoc.conf.json",
     "tsd": "jsdoc src/ -r -t node_modules/tsd-jsdoc/dist -d lib/"
   },
-  "husky": {
-    "hooks": {
-      "pre-push": "npm run lint"
-    }
-  },
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
@@ -72,7 +67,6 @@
     "eslint": "^5.16.0",
     "eslint-config-google": "^0.12.0",
     "eslint-plugin-no-only-tests": "^2.3.0",
-    "husky": "^1.3.1",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
     "jest-when": "^2.4.0",

--- a/src/http/http-request-config-builder.js
+++ b/src/http/http-request-config-builder.js
@@ -35,6 +35,26 @@ class HttpRequestConfigBuilder {
   }
 
   /**
+   * Sets the headers map.
+   *
+   * @param {Object<string, string>} headers the headers map
+   * @return {HttpRequestConfigBuilder}
+   */
+  setHeaders(headers) {
+    this.config.headers = headers;
+    return this;
+  }
+
+  /**
+   * Returns the headers map.
+   *
+   * @return {Object<string, string>}
+   */
+  getHeaders() {
+    return this.config.headers;
+  }
+
+  /**
    * Add a specific header of type <code>Accept</code> with the given value.
    *
    * @param {string} value
@@ -70,15 +90,27 @@ class HttpRequestConfigBuilder {
    * Add a new request param.
    *
    * @param {string} param
-   * @param {any} value
+   * @param {*} value
    * @return {HttpRequestConfigBuilder}
    */
   addParam(param, value) {
+    if (!value) {
+      return this;
+    }
     if (!this.config.params) {
       this.config.params = {};
     }
     this.config.params[param] = value;
     return this;
+  }
+
+  /**
+   * Returns the request parameters map.
+   *
+   * @return {Object<string, *>}
+   */
+  getParams() {
+    return this.config.params;
   }
 
   /**
@@ -90,6 +122,15 @@ class HttpRequestConfigBuilder {
   setTimeout(timeout) {
     this.config.timeout = timeout;
     return this;
+  }
+
+  /**
+   * Returns the request timeout.
+   *
+   * @return {number}
+   */
+  getTimeout() {
+    return this.config.timeout;
   }
 
   /**

--- a/src/repository/base-repository-client.js
+++ b/src/repository/base-repository-client.js
@@ -74,11 +74,11 @@ class BaseRepositoryClient {
   initHttpClients() {
     const config = this.repositoryClientConfig;
     // Constructs a http client for each endpoint
-    this.httpClients = config.endpoints.map((endpoint) => {
+    this.httpClients = config.getEndpoints().map((endpoint) => {
       return new HttpClient(endpoint)
-        .setDefaultHeaders(config.headers)
-        .setDefaultReadTimeout(config.readTimeout)
-        .setDefaultWriteTimeout(config.writeTimeout);
+        .setDefaultHeaders(config.getHeaders())
+        .setDefaultReadTimeout(config.getReadTimeout())
+        .setDefaultWriteTimeout(config.getWriteTimeout());
     });
   }
 
@@ -254,7 +254,7 @@ class BaseRepositoryClient {
         + 'type!');
     }
 
-    const endpoints = repositoryClientConfig.endpoints;
+    const endpoints = repositoryClientConfig.getEndpoints();
     if (!endpoints || !endpoints.length) {
       throw new Error('Cannot instantiate a repository without repository '
         + 'endpoint configuration! At least one endpoint must be provided.');

--- a/src/repository/repository-client-config.js
+++ b/src/repository/repository-client-config.js
@@ -8,11 +8,11 @@
  */
 class RepositoryClientConfig {
   /**
-   * @param {string[]} endpoints is an array with repository endpoints
-   * @param {Object} headers is a key:value mapping of http headers and values
-   * @param {string} defaultRDFMimeType one of {@link RDFMimeType} values
-   * @param {number} readTimeout
-   * @param {number} writeTimeout
+   * @param {string[]} [endpoints] is an array with repository endpoints
+   * @param {Object} [headers] is a key:value mapping of http headers and values
+   * @param {string} [defaultRDFMimeType] one of {@link RDFMimeType} values
+   * @param {number} [readTimeout]
+   * @param {number} [writeTimeout]
    */
   constructor(endpoints, headers, defaultRDFMimeType, readTimeout,
       writeTimeout) {
@@ -21,6 +21,126 @@ class RepositoryClientConfig {
     this.defaultRDFMimeType = defaultRDFMimeType;
     this.readTimeout = readTimeout;
     this.writeTimeout = writeTimeout;
+  }
+
+  /**
+   * Sets the repository endpoint URLs.
+   *
+   * @param {string[]} endpoints the endpoint URLs
+   *
+   * @return {RepositoryClientConfig} current config for method chaining
+   */
+  setEndpoints(endpoints) {
+    this.endpoints = endpoints;
+    return this;
+  }
+
+  /**
+   * Inserts a repository endpoint URL to the rest of the endpoints.
+   *
+   * @param {string} endpoint repository endpoint URL
+   *
+   * @return {RepositoryClientConfig} current config for method chaining
+   */
+  addEndpoint(endpoint) {
+    if (!this.endpoints) {
+      this.endpoints = [];
+    }
+    this.endpoints.push(endpoint);
+    return this;
+  }
+
+  /**
+   * Gets the repository endpoint URLs.
+   *
+   * @return {string[]}
+   */
+  getEndpoints() {
+    return this.endpoints;
+  }
+
+  /**
+   * Sets the default headers map for each HTTP request.
+   *
+   * @param {Object<string, string>} headers the map of default headers
+   *
+   * @return {RepositoryClientConfig} current config for method chaining
+   */
+  setHeaders(headers) {
+    this.headers = headers;
+    return this;
+  }
+
+  /**
+   * Returns the default headers map for each HTTP request.
+   *
+   * @return {Object<string, string>}
+   */
+  getHeaders() {
+    return this.headers;
+  }
+
+  /**
+   * Sets the default RDF MIME type.
+   *
+   * @param {string} defaultRDFMimeType
+   *
+   * @return {RepositoryClientConfig} current config for method chaining
+   */
+  setDefaultRDFMimeType(defaultRDFMimeType) {
+    this.defaultRDFMimeType = defaultRDFMimeType;
+    return this;
+  }
+
+  /**
+   * Returns the default RDF MIME type.
+   *
+   * @return {string}
+   */
+  getDefaultRDFMimeType() {
+    return this.defaultRDFMimeType;
+  }
+
+  /**
+   * Sets the default read timeout for HTTP requests.
+   *
+   * @param {number} readTimeout the timeout in milliseconds
+   *
+   * @return {RepositoryClientConfig} current config for method chaining
+   */
+  setReadTimeout(readTimeout) {
+    this.readTimeout = readTimeout;
+    return this;
+  }
+
+  /**
+   * Returns the default read timeout for HTTP requests.
+   *
+   * @return {number}
+   */
+  getReadTimeout() {
+    return this.readTimeout;
+  }
+
+  /**
+   * Sets the default write timeout for HTTP requests.
+   *
+   * @param {number} writeTimeout the timeout in milliseconds
+   *
+   * @return {RepositoryClientConfig} current config for method chaining
+   */
+  setWriteTimeout(writeTimeout) {
+    this.writeTimeout = writeTimeout;
+    return this;
+  }
+
+  /**
+   * Returns the default write timeout for HTTP requests.
+   *
+   * @return {number}
+   */
+  getWriteTimeout() {
+    return this.writeTimeout;
   }
 }
 

--- a/src/server/server-client-config.js
+++ b/src/server/server-client-config.js
@@ -8,15 +8,78 @@
  */
 class ServerClientConfig {
   /**
-   * @param {string} endpoint Endpoint url.
-   * @param {number} timeout Specifies the number of milliseconds before the
+   * @param {string} [endpoint] Endpoint url.
+   * @param {number} [timeout] Specifies the number of milliseconds before the
    *                         request times out.
-   * @param {Map<string, string>} headers An http headers map.
+   * @param {Map<string, string>} [headers] An http headers map.
    */
   constructor(endpoint, timeout, headers) {
     this.endpoint = endpoint;
     this.timeout = timeout;
     this.headers = headers;
+  }
+
+  /**
+   * Sets the server's endpoint URL.
+   *
+   * @param {string} endpoint the endpoint URL
+   *
+   * @return {ServerClientConfig} the current config for method chaining
+   */
+  setEndpoint(endpoint) {
+    this.endpoint = endpoint;
+    return this;
+  }
+
+  /**
+   * Returns the server's endpoint URL.
+   *
+   * @return {string} the endpoint URL
+   */
+  getEndpoint() {
+    return this.endpoint;
+  }
+
+  /**
+   * Sets the default headers map for each HTTP request.
+   *
+   * @param {Object<string, string>} headers the default headers
+   *
+   * @return {ServerClientConfig} the current config for method chaining
+   */
+  setHeaders(headers) {
+    this.headers = headers;
+    return this;
+  }
+
+  /**
+   * Returns the default headers for each HTTP request.
+   *
+   * @return {Object<string, string>} the default headers map
+   */
+  getHeaders() {
+    return this.headers;
+  }
+
+  /**
+   * Sets the timeout for HTTP requests.
+   *
+   * @param {number} timeout the timeout in milliseconds
+   *
+   * @return {ServerClientConfig} the current config for method chaining
+   */
+  setTimeout(timeout) {
+    this.timeout = timeout;
+    return this;
+  }
+
+  /**
+   * Returns the HTTP requests's timeout.
+   *
+   * @return {number} the timeout in milliseconds
+   */
+  getTimeout() {
+    return this.timeout;
   }
 }
 

--- a/src/server/server-client.js
+++ b/src/server/server-client.js
@@ -32,8 +32,7 @@ class ServerClient {
    */
   getRepositoryIDs() {
     const requestConfig = new HttpRequestConfigBuilder()
-      .addAcceptHeader(RDFMimeType.SPARQL_RESULTS_JSON)
-      .get();
+      .addAcceptHeader(RDFMimeType.SPARQL_RESULTS_JSON);
 
     let elapsedTime = Date.now();
     return this.httpClient.get(SERVICE_URL, requestConfig).then((response) => {
@@ -105,7 +104,9 @@ class ServerClient {
    * Initializes the http client.
    */
   initHttpClient() {
-    this.httpClient = new HttpClient(this.config.endpoint);
+    this.httpClient = new HttpClient(this.config.getEndpoint())
+      .setDefaultReadTimeout(this.config.getTimeout())
+      .setDefaultWriteTimeout(this.config.getTimeout());
   }
 
   /**
@@ -114,7 +115,7 @@ class ServerClient {
   initLogger() {
     this.logger = new ConsoleLogger({
       name: 'ServerClient',
-      serverURL: this.config.endpoint
+      serverURL: this.config.getEndpoint()
     });
   }
 }

--- a/src/transaction/transactional-repository-client.js
+++ b/src/transaction/transactional-repository-client.js
@@ -67,8 +67,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       .setParams({
         action: 'SIZE',
         context: TermConverter.toNTripleValues(context)
-      })
-      .get();
+      });
 
     return this.execute((http) => http.put('', null, requestConfig))
       .then((response) => {
@@ -108,7 +107,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       requestConfig.setResponseType('stream');
     }
 
-    return this.execute((http) => http.put('', null, requestConfig.get()))
+    return this.execute((http) => http.put('', null, requestConfig))
       .then((response) => {
         this.logger.debug(this.getLogPayload(response, {
           subject: payload.getSubject(),
@@ -136,8 +135,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       .addContentTypeHeader(payload.getContentType())
       .setParams({
         action: 'QUERY'
-      })
-      .get();
+      });
 
     return this.execute((http) => http.put('', payload.getParams(),
       requestConfig)).then((response) => {
@@ -164,8 +162,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       .addContentTypeHeader(payload.getContentType())
       .setParams({
         action: 'UPDATE'
-      })
-      .get();
+      });
 
     return this.execute((http) => http.put('', payload.getParams(),
       requestConfig)).then((response) => {
@@ -260,8 +257,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         context: TermConverter.toNTripleValues(context),
         baseURI
       })
-      .addContentTypeHeader(RDFMimeType.TRIG)
-      .get();
+      .addContentTypeHeader(RDFMimeType.TRIG);
 
     return this.execute((http) => http.put('', data, requestConfig))
       .then((response) => {
@@ -290,8 +286,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       .setParams({
         action: 'DELETE'
       })
-      .addContentTypeHeader(RDFMimeType.TRIG)
-      .get();
+      .addContentTypeHeader(RDFMimeType.TRIG);
 
     return this.execute((http) => http.put('', data, requestConfig))
       .then((response) => {
@@ -325,8 +320,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         obj: TermConverter.toNTripleValue(payload.getObject()),
         context: TermConverter.toNTripleValues(payload.getContext()),
         infer: payload.getInference()
-      })
-      .get();
+      });
 
     return this.execute((http) => http.put('', null, requestConfig))
       .then((response) => {
@@ -421,8 +415,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         action: 'ADD',
         context: TermConverter.toNTripleValues(context),
         baseURI
-      })
-      .get();
+      });
 
     return this.execute((http) => http.put('', readStream, requestConfig));
   }
@@ -439,8 +432,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
     const requestConfig = new HttpRequestConfigBuilder()
       .setParams({
         action: 'COMMIT'
-      })
-      .get();
+      });
 
     return this.execute((http) => http.put('', null, requestConfig))
       .then((response) => {

--- a/src/util/common-utils.js
+++ b/src/util/common-utils.js
@@ -8,7 +8,6 @@ class CommonUtils {
   /**
    * Checks if at least one of the supplied arguments is undefined or null.
    *
-   * @private
    * @return {boolean} <code>true</code> if there is null argument or
    *         <code>false</code> otherwise
    */

--- a/test/http/http-client.spec.js
+++ b/test/http/http-client.spec.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const HttpClient = require('http/http-client');
+const HttpRequestConfigBuilder = require('http/http-request-config-builder');
 
 jest.mock('axios');
 
@@ -35,14 +36,11 @@ describe('HttpClient', () => {
     axiosMock.put.mockResolvedValue();
     axiosMock.delete.mockResolvedValue();
 
-    requestConfig = {
-      params: {
-        'param-1': 'value-1'
-      },
-      headers: {
-        'Accept': 'application/json'
-      }
-    };
+    requestConfig = new HttpRequestConfigBuilder().setParams({
+      'param-1': 'value-1'
+    }).setHeaders({
+      'Accept': 'application/json'
+    });
 
     httpClient = new HttpClient('/base/url')
       .setDefaultReadTimeout(1000)
@@ -91,7 +89,7 @@ describe('HttpClient', () => {
     test('should perform GET requests with the supplied params', () => {
       return httpClient.get('/api/resources', requestConfig).then(() => {
         expect(axiosMock.get).toHaveBeenCalledTimes(1);
-        expect(axiosMock.get).toHaveBeenCalledWith('/api/resources', requestConfig);
+        expect(axiosMock.get).toHaveBeenCalledWith('/api/resources', requestConfig.config);
       });
     });
 
@@ -108,7 +106,7 @@ describe('HttpClient', () => {
     });
 
     test('should not add default read timeout to request configuration if already provided', () => {
-      requestConfig.timeout = 500;
+      requestConfig.setTimeout(500);
       return httpClient.get('/api/resources', requestConfig).then(() => {
         expect(axiosMock.get.mock.calls[0][1].timeout).toEqual(500);
       });
@@ -128,7 +126,7 @@ describe('HttpClient', () => {
     test('should perform POST requests with the supplied params and data', () => {
       return httpClient.post('/api/resources', requestData, requestConfig).then(() => {
         expect(axiosMock.post).toHaveBeenCalledTimes(1);
-        expect(axiosMock.post).toHaveBeenCalledWith('/api/resources', requestData, requestConfig);
+        expect(axiosMock.post).toHaveBeenCalledWith('/api/resources', requestData, requestConfig.config);
       });
     });
 
@@ -145,7 +143,7 @@ describe('HttpClient', () => {
     });
 
     test('should not add default read timeout to request configuration if already provided', () => {
-      requestConfig.timeout = 500;
+      requestConfig.setTimeout(500);
       return httpClient.post('/api/resources', requestData, requestConfig).then(() => {
         expect(axiosMock.post.mock.calls[0][2].timeout).toEqual(500);
       });
@@ -165,7 +163,7 @@ describe('HttpClient', () => {
     test('should perform PUT requests with the supplied params and data', () => {
       return httpClient.put('/api/resources/1/', requestData, requestConfig).then(() => {
         expect(axiosMock.put).toHaveBeenCalledTimes(1);
-        expect(axiosMock.put).toHaveBeenCalledWith('/api/resources/1/', requestData, requestConfig);
+        expect(axiosMock.put).toHaveBeenCalledWith('/api/resources/1/', requestData, requestConfig.config);
       });
     });
 
@@ -182,7 +180,7 @@ describe('HttpClient', () => {
     });
 
     test('should not add default read timeout to request configuration if already provided', () => {
-      requestConfig.timeout = 500;
+      requestConfig.setTimeout(500);
       return httpClient.put('/api/resources', requestData, requestConfig).then(() => {
         expect(axiosMock.put.mock.calls[0][2].timeout).toEqual(500);
       });
@@ -202,7 +200,7 @@ describe('HttpClient', () => {
     test('should perform DELETE requests with the supplied params', () => {
       return httpClient.deleteResource('/api/resources/1/', requestConfig).then(() => {
         expect(axiosMock.delete).toHaveBeenCalledTimes(1);
-        expect(axiosMock.delete).toHaveBeenCalledWith('/api/resources/1/', requestConfig);
+        expect(axiosMock.delete).toHaveBeenCalledWith('/api/resources/1/', requestConfig.config);
       });
     });
 
@@ -219,7 +217,7 @@ describe('HttpClient', () => {
     });
 
     test('should not add default read timeout to request configuration if already provided', () => {
-      requestConfig.timeout = 500;
+      requestConfig.setTimeout(500);
       return httpClient.deleteResource('/api/resources', requestConfig).then(() => {
         expect(axiosMock.delete.mock.calls[0][1].timeout).toEqual(500);
       });

--- a/test/http/http-request-config-builder.spec.js
+++ b/test/http/http-request-config-builder.spec.js
@@ -42,6 +42,18 @@ describe('HttpRequestConfigBuilder', () => {
       });
   });
 
+  test('should get the params mapping', () => {
+    expect(new HttpRequestConfigBuilder()
+      .addParam('subj', 'subj')
+      .addParam('pred', 'pred')
+      .getParams())
+      .toEqual({
+        subj: 'subj',
+        pred: 'pred'
+      });
+  });
+
+
   test('should should set timeout configuration', () => {
     expect(new HttpRequestConfigBuilder()
       .setTimeout(1000)
@@ -49,6 +61,13 @@ describe('HttpRequestConfigBuilder', () => {
       .toEqual({
         timeout: 1000
       });
+  });
+
+  test('should get the timeout configuration', () => {
+    expect(new HttpRequestConfigBuilder()
+      .setTimeout(1000)
+      .getTimeout())
+      .toEqual(1000);
   });
 
   test('should should set response type configuration', () => {
@@ -85,5 +104,14 @@ describe('HttpRequestConfigBuilder', () => {
       .addHeader('custom', null)
       .get())
       .toEqual({});
+  });
+
+  test('should get the headers', () => {
+    expect(new HttpRequestConfigBuilder()
+      .addContentTypeHeader('text/turtle')
+      .getHeaders())
+      .toEqual({
+        'Content-Type': 'text/turtle'
+      });
   });
 });

--- a/test/repository/base-repository-client-failover.spec.js
+++ b/test/repository/base-repository-client-failover.spec.js
@@ -12,11 +12,14 @@ describe('BaseRepositoryClient', () => {
 
   describe('Automatic failover - retrying with different repo endpoint', () => {
     beforeEach(() => {
-      repoClientConfig = new RepositoryClientConfig([
-        'http://localhost:8081/repositories/test1',
-        'http://localhost:8082/repositories/test2',
-        'http://localhost:8083/repositories/test3'
-      ], {}, '', 100, 200, 50, 2);
+      repoClientConfig = new RepositoryClientConfig()
+        .setEndpoints([
+          'http://localhost:8081/repositories/test1',
+          'http://localhost:8082/repositories/test2',
+          'http://localhost:8083/repositories/test3'
+        ])
+        .setReadTimeout(100)
+        .setWriteTimeout(200);
 
       HttpClient.mockImplementation(() => httpClientStub());
 

--- a/test/repository/rdf-repository-client-deleting-data.spec.js
+++ b/test/repository/rdf-repository-client-deleting-data.spec.js
@@ -1,6 +1,7 @@
 const HttpClient = require('http/http-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const RDFRepositoryClient = require('repository/rdf-repository-client');
+const HttpRequestConfigBuilder = require('http/http-request-config-builder');
 const httpClientStub = require('../http/http-client.stub');
 const {when} = require('jest-when');
 
@@ -20,9 +21,10 @@ describe('RDFRepositoryClient - Deleting statements', () => {
   let rdfRepositoryClient;
 
   beforeEach(() => {
-    repoClientConfig = new RepositoryClientConfig([
-      'http://localhost:8080/repositories/test'
-    ], {}, '', 100, 200);
+    repoClientConfig = new RepositoryClientConfig()
+      .addEndpoint('http://localhost:8080/repositories/test')
+      .setReadTimeout(100)
+      .setWriteTimeout(200);
 
     HttpClient.mockImplementation(() => httpClientStub());
 
@@ -34,11 +36,9 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(subj).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', {
-          params: {
-            subj, pred: undefined, obj: undefined, context: undefined
-          }
-        });
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+          subj, pred: undefined, obj: undefined, context: undefined
+        }));
       });
     });
 
@@ -46,11 +46,9 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(subj, pred, obj).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', {
-          params: {
-            subj, pred, obj, context: undefined
-          }
-        });
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+          subj, pred, obj, context: undefined
+        }));
       });
     });
 
@@ -59,11 +57,9 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(subj, pred, obj, contexts).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', {
-          params: {
-            subj, pred, obj, context: contexts
-          }
-        });
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+          subj, pred, obj, context: contexts
+        }));
       });
     });
 
@@ -71,11 +67,9 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(null, null, null, context).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', {
-          params: {
-            subj: undefined, pred: undefined, obj: undefined, context
-          }
-        });
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+          subj: undefined, pred: undefined, obj: undefined, context
+        }));
       });
     });
 
@@ -92,11 +86,9 @@ describe('RDFRepositoryClient - Deleting statements', () => {
         'http://domain/graph/1').then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', {
-          params: {
-            subj, pred, obj, context
-          }
-        });
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+          subj, pred, obj, context
+        }));
       });
     });
 

--- a/test/repository/rdf-repository-client-namespaces.spec.js
+++ b/test/repository/rdf-repository-client-namespaces.spec.js
@@ -5,6 +5,7 @@ const RDFMimeType = require('http/rdf-mime-type');
 const DataFactory = require('n3').DataFactory;
 const NamedNode = DataFactory.internal.NamedNode;
 const Namespace = require('model/namespace');
+const HttpRequestConfigBuilder = require('http/http-request-config-builder');
 const httpClientStub = require('../http/http-client.stub');
 const namespaceData = require('./data/namespaces.json');
 
@@ -19,9 +20,10 @@ describe('RDFRepositoryClient - Namespace management', () => {
   let rdfRepositoryClient;
 
   beforeEach(() => {
-    repoClientConfig = new RepositoryClientConfig([
-      'http://localhost:8080/repositories/test'
-    ], {}, '', 100, 200);
+    repoClientConfig = new RepositoryClientConfig()
+      .addEndpoint('http://localhost:8080/repositories/test')
+      .setReadTimeout(100)
+      .setWriteTimeout(200);
 
     HttpClient.mockImplementation(() => stubHttpClient());
 
@@ -41,9 +43,9 @@ describe('RDFRepositoryClient - Namespace management', () => {
 
         let get = rdfRepositoryClient.httpClients[0].get;
         expect(get).toHaveBeenCalledTimes(1);
-        expect(get).toHaveBeenCalledWith('/namespaces', {
-          headers: {'Accept': RDFMimeType.SPARQL_RESULTS_JSON}
-        });
+        expect(get).toHaveBeenCalledWith('/namespaces', new HttpRequestConfigBuilder().setHeaders({
+          'Accept': RDFMimeType.SPARQL_RESULTS_JSON
+        }));
       });
     });
 

--- a/test/repository/rdf-repository-client-streaming-data.spec.js
+++ b/test/repository/rdf-repository-client-streaming-data.spec.js
@@ -2,6 +2,7 @@ const HttpClient = require('http/http-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const RdfRepositoryClient = require('repository/rdf-repository-client');
 const RDFMimeType = require('http/rdf-mime-type');
+const HttpRequestConfigBuilder = require('http/http-request-config-builder');
 const {ObjectReadableMock} = require('stream-mock');
 
 const httpClientStub = require('../http/http-client.stub');
@@ -21,7 +22,12 @@ describe('RdfRepositoryClient - streaming data', () => {
   beforeEach(() => {
     HttpClient.mockImplementation(() => httpClientStub());
 
-    repoClientConfig = new RepositoryClientConfig(endpoints, headers, contentType, readTimeout, writeTimeout);
+    repoClientConfig = new RepositoryClientConfig()
+      .setEndpoints(endpoints)
+      .setHeaders(headers)
+      .setDefaultRDFMimeType(contentType)
+      .setReadTimeout(readTimeout)
+      .setWriteTimeout(writeTimeout);
     rdfRepositoryClient = new RdfRepositoryClient(repoClientConfig);
   });
 
@@ -62,17 +68,15 @@ describe('RdfRepositoryClient - streaming data', () => {
     });
 
     function verifyUploadRequest(postMock) {
+      const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+        'Content-Type': 'text/turtle'
+      }).setParams({
+        context,
+        baseURI
+      }).setResponseType('stream');
+
       expect(postMock).toHaveBeenCalledTimes(1);
-      expect(postMock).toHaveBeenCalledWith('/statements', {}, {
-        headers: {
-          'Content-Type': 'text/turtle'
-        },
-        params: {
-          context,
-          baseURI
-        },
-        responseType: 'stream'
-      });
+      expect(postMock).toHaveBeenCalledWith('/statements', {}, expectedRequestConfig);
     }
   });
 
@@ -113,17 +117,15 @@ describe('RdfRepositoryClient - streaming data', () => {
     });
 
     function verifyOverwriteRequest(putMock) {
+      const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+        'Content-Type': 'text/turtle'
+      }).setParams({
+        context,
+        baseURI
+      }).setResponseType('stream');
+
       expect(putMock).toHaveBeenCalledTimes(1);
-      expect(putMock).toHaveBeenCalledWith('/statements', {}, {
-        headers: {
-          'Content-Type': 'text/turtle'
-        },
-        params: {
-          context,
-          baseURI
-        },
-        responseType: 'stream'
-      });
+      expect(putMock).toHaveBeenCalledWith('/statements', {}, expectedRequestConfig);
     }
   });
 

--- a/test/repository/rdf-repository-client-uploading-files.spec.js
+++ b/test/repository/rdf-repository-client-uploading-files.spec.js
@@ -2,6 +2,7 @@ const HttpClient = require('http/http-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const RdfRepositoryClient = require('repository/rdf-repository-client');
 const RDFMimeType = require('http/rdf-mime-type');
+const HttpRequestConfigBuilder = require('http/http-request-config-builder');
 
 const httpClientStub = require('../http/http-client.stub');
 const testUtils = require('../utils');
@@ -28,7 +29,12 @@ describe('RdfRepositoryClient - uploading files', () => {
 
   beforeEach(() => {
     HttpClient.mockImplementation(() => httpClientStub());
-    repoClientConfig = new RepositoryClientConfig(endpoints, headers, contentType, readTimeout, writeTimeout);
+    repoClientConfig = new RepositoryClientConfig()
+      .setEndpoints(endpoints)
+      .setHeaders(headers)
+      .setDefaultRDFMimeType(contentType)
+      .setReadTimeout(readTimeout)
+      .setWriteTimeout(writeTimeout);
     rdfRepositoryClient = new RdfRepositoryClient(repoClientConfig);
   });
 
@@ -48,17 +54,15 @@ describe('RdfRepositoryClient - uploading files', () => {
         const url = httpPostCall[0];
         expect(url).toEqual('/statements');
 
+        const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+          'Content-Type': RDFMimeType.TRIG
+        }).setParams({
+          baseURI,
+          context
+        }).setResponseType('stream');
+
         const requestConfig = httpPostCall[2];
-        expect(requestConfig).toEqual({
-          headers: {
-            'Content-Type': RDFMimeType.TRIG
-          },
-          params: {
-            baseURI,
-            context
-          },
-          responseType: 'stream'
-        });
+        expect(requestConfig).toEqual(expectedRequestConfig);
 
         const fileStream = httpPostCall[1];
         return testUtils.readStream(fileStream)
@@ -103,17 +107,15 @@ describe('RdfRepositoryClient - uploading files', () => {
         const url = httpPutCall[0];
         expect(url).toEqual('/statements');
 
+        const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+          'Content-Type': RDFMimeType.TRIG
+        }).setParams({
+          baseURI,
+          context
+        }).setResponseType('stream');
+
         const requestConfig = httpPutCall[2];
-        expect(requestConfig).toEqual({
-          headers: {
-            'Content-Type': RDFMimeType.TRIG
-          },
-          params: {
-            baseURI,
-            context
-          },
-          responseType: 'stream'
-        });
+        expect(requestConfig).toEqual(expectedRequestConfig);
 
         const fileStream = httpPutCall[1];
         return testUtils.readStream(fileStream)

--- a/test/repository/repository-client-config.spec.js
+++ b/test/repository/repository-client-config.spec.js
@@ -1,0 +1,46 @@
+const RepositoryClientConfig = require('repository/repository-client-config');
+const RDFMimeType = require('http/rdf-mime-type');
+
+describe('RepositoryClientConfig', () => {
+
+  const endpoints = [
+    'http://localhost:8081/repositories/test1',
+    'http://localhost:8082/repositories/test2',
+    'http://localhost:8083/repositories/test3'
+  ];
+  const headers = {
+    'Accept': 'application/json'
+  };
+  const defaultRDFMimeType = RDFMimeType.TURTLE;
+  const readTimeout = 1000;
+  const writeTimeout = 2000;
+
+  test('should instantiate with the provided configuration parameters', () => {
+    const config = new RepositoryClientConfig(endpoints, headers, defaultRDFMimeType, readTimeout, writeTimeout);
+    expect(config.getEndpoints()).toEqual(endpoints);
+    expect(config.getHeaders()).toEqual(headers);
+    expect(config.getDefaultRDFMimeType()).toEqual(defaultRDFMimeType);
+    expect(config.getReadTimeout()).toEqual(readTimeout);
+    expect(config.getWriteTimeout()).toEqual(writeTimeout);
+  });
+
+  test('should support initialization via fluent API', () => {
+    const config = new RepositoryClientConfig()
+      .setEndpoints(endpoints)
+      .setHeaders(headers)
+      .setDefaultRDFMimeType(defaultRDFMimeType)
+      .setReadTimeout(readTimeout)
+      .setWriteTimeout(writeTimeout);
+    expect(config.getEndpoints()).toEqual(endpoints);
+    expect(config.getHeaders()).toEqual(headers);
+    expect(config.getDefaultRDFMimeType()).toEqual(defaultRDFMimeType);
+    expect(config.getReadTimeout()).toEqual(readTimeout);
+    expect(config.getWriteTimeout()).toEqual(writeTimeout);
+  });
+
+  test('should allow addition of repository endpoints', () => {
+    const config = new RepositoryClientConfig();
+    endpoints.forEach(endpoint => config.addEndpoint(endpoint));
+    expect(config.getEndpoints()).toEqual(endpoints);
+  });
+});

--- a/test/server/server-client-config.spec.js
+++ b/test/server/server-client-config.spec.js
@@ -1,0 +1,22 @@
+const ServerClientConfig = require('server/server-client-config');
+
+describe('ServerClientConfig', () => {
+  test('should initialize with the supplied parameters', () => {
+    const headers = {'Accept': 'text/plain'};
+    const config = new ServerClientConfig('/endpoint', 1000, headers);
+    expect(config.getEndpoint()).toEqual('/endpoint');
+    expect(config.getTimeout()).toEqual(1000);
+    expect(config.getHeaders()).toEqual(headers);
+  });
+
+  test('should support initialization via fluent API ', () => {
+    const headers = {'Accept': 'text/plain'};
+    const config = new ServerClientConfig()
+      .setEndpoint('/endpoint')
+      .setTimeout(1000)
+      .setHeaders(headers);
+    expect(config.getEndpoint()).toEqual('/endpoint');
+    expect(config.getTimeout()).toEqual(1000);
+    expect(config.getHeaders()).toEqual(headers);
+  });
+});

--- a/test/util/common-utils.spec.js
+++ b/test/util/common-utils.spec.js
@@ -1,0 +1,14 @@
+const CommonUtils = require('util/common-utils');
+
+describe('CommonUtils', () => {
+  test('hasNullArguments()', () => {
+    expect(CommonUtils.hasNullArguments()).toEqual(false);
+    expect(CommonUtils.hasNullArguments(null)).toEqual(true);
+    expect(CommonUtils.hasNullArguments('')).toEqual(true);
+    expect(CommonUtils.hasNullArguments('', null)).toEqual(true);
+    expect(CommonUtils.hasNullArguments('abc', null)).toEqual(true);
+    expect(CommonUtils.hasNullArguments(null, '')).toEqual(true);
+    expect(CommonUtils.hasNullArguments(null, 'abc')).toEqual(true);
+    expect(CommonUtils.hasNullArguments('abc')).toEqual(false);
+  });
+});


### PR DESCRIPTION
Changed HttpClient to accept HttpRequestConfigBuilder as param to hide
Axios request config structure. Reduced code duplication in HttpClient
in result. Updated the uses and tests.

Changed ServerClientConfig and RepositoryClientConfig with fluent
getters/setters to avoid constructing them via constructor params.

Updated Travis config to include Node 12 and to perform eslint check.
Removed Husky due to Travis invoking eslint.