### PR TITLE
Rework HTTP requests builder and HTPP client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1877,18 +1877,6 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
-    "bunyan": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
-      "dev": true,
-      "requires": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.10.6",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      }
-    },
     "cacache": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
@@ -2532,12 +2520,6 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
-    },
     "diff-sequences": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
@@ -2577,16 +2559,6 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
-      }
-    },
-    "dtrace-provider": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
-      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.10.0"
       }
     },
     "duplexify": {
@@ -2973,57 +2945,6 @@
         }
       }
     },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "^2.1.0"
-      },
-      "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -3217,12 +3138,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
     "fileset": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -3359,15 +3274,6 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "^1.0.1"
-      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -4027,42 +3933,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -4540,21 +4410,6 @@
         }
       }
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4616,18 +4471,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -5215,185 +5058,6 @@
         "string-length": "^2.0.0"
       }
     },
-    "jest-when": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-2.4.0.tgz",
-      "integrity": "sha512-Xf2QStQOnIF5bnyvuRh1iIBSX9iW8IgNon24Ab4MAQjLtFDgJrxDhpx7zoJvhLWYaBKRyqbTBWLlbd4r0lkLrA==",
-      "dev": true,
-      "requires": {
-        "bunyan": "^1.8.12",
-        "expect": "^22.4.3"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expect": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
-          "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "jest-diff": "^22.4.3",
-            "jest-get-type": "^22.4.3",
-            "jest-matcher-utils": "^22.4.3",
-            "jest-message-util": "^22.4.3",
-            "jest-regex-util": "^22.4.3"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "jest-diff": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-          "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "diff": "^3.2.0",
-            "jest-get-type": "^22.4.3",
-            "pretty-format": "^22.4.3"
-          }
-        },
-        "jest-get-type": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-          "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-          "dev": true
-        },
-        "jest-matcher-utils": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-          "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "jest-get-type": "^22.4.3",
-            "pretty-format": "^22.4.3"
-          }
-        },
-        "jest-message-util": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
-          "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0-beta.35",
-            "chalk": "^2.0.1",
-            "micromatch": "^2.3.11",
-            "slash": "^1.0.0",
-            "stack-utils": "^1.0.1"
-          }
-        },
-        "jest-regex-util": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-          "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "pretty-format": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-          "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0",
-            "ansi-styles": "^3.2.0"
-          }
-        },
-        "slash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-          "dev": true
-        }
-      }
-    },
     "jest-worker": {
       "version": "24.6.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
@@ -5839,12 +5503,6 @@
       "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
       "dev": true
     },
-    "math-random": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
-      "dev": true
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -6035,13 +5693,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true,
-      "optional": true
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -6067,44 +5718,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^6.0.1"
-          }
-        }
-      }
     },
     "n3": {
       "version": "1.0.5",
@@ -6142,13 +5755,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "dev": true,
-      "optional": true
     },
     "neo-async": {
       "version": "2.6.0",
@@ -6348,16 +5954,6 @@
         "es-abstract": "^1.5.1"
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      }
-    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -6543,35 +6139,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -6730,12 +6297,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
     "pretty-format": {
       "version": "24.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
@@ -6883,25 +6444,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
       "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA=="
     },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7015,15 +6557,6 @@
       "dev": true,
       "requires": {
         "private": "^0.1.6"
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -7314,13 +6847,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "dev": true,
-      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-config-google": "^0.12.0",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "jest": "^24.7.1",
-    "jest-when": "^2.4.0",
     "jsdoc": "^3.6.2",
     "stream-mock": "^2.0.2",
     "tsd-jsdoc": "^2.1.3",

--- a/src/http/http-client.js
+++ b/src/http/http-client.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const uuidv4 = require('uuid/v4');
 const qs = require('qs');
 const ConsoleLogger = require('../logging/console-logger');
-const HttpRequestConfigBuilder = require('./http-request-config-builder');
+const HttpRequestBuilder = require('./http-request-builder');
 
 const REQUEST_ID_HEADER = 'x-request-id';
 
@@ -100,7 +100,7 @@ class HttpClient {
    * given URL.
    *
    * @param {string} url URL to the requested resource
-   * @param {HttpRequestConfigBuilder} [requestConfigBuilder] request
+   * @param {HttpRequestBuilder} [requestConfigBuilder] request
    * configuration builder that include params and headers
    * @return {Promise<any>} a promise resolving to the request's response
    */
@@ -119,7 +119,7 @@ class HttpClient {
    *
    * @param {string} url URL to the requested resource
    * @param {object} data the request body
-   * @param {HttpRequestConfigBuilder} [requestConfigBuilder] request
+   * @param {HttpRequestBuilder} [requestConfigBuilder] request
    * configuration builder that include params and headers
    * @return {Promise<any>} a promise resolving to the request's response
    */
@@ -138,7 +138,7 @@ class HttpClient {
    *
    * @param {string} url URL to the requested resource
    * @param {object} data the request body
-   * @param {HttpRequestConfigBuilder} [requestConfigBuilder] request
+   * @param {HttpRequestBuilder} [requestConfigBuilder] request
    * configuration builder that include params and headers
    * @return {Promise<any>} a promise resolving to the request's response
    */
@@ -156,7 +156,7 @@ class HttpClient {
    * given URL.
    *
    * @param {string} url URL to the requested resource
-   * @param {HttpRequestConfigBuilder} [requestConfigBuilder] request
+   * @param {HttpRequestBuilder} [requestConfigBuilder] request
    * configuration builder that include params and headers
    * @return {Promise<any>} a promise resolving to the request's response
    */
@@ -171,7 +171,7 @@ class HttpClient {
    * provided request configuration builder.
    *
    * @private
-   * @param {HttpRequestConfigBuilder} [requestConfigBuilder] request
+   * @param {HttpRequestBuilder} [requestConfigBuilder] request
    * configuration builder used to produce the request configuration
    * @return {Object<string, string>}
    */
@@ -184,7 +184,7 @@ class HttpClient {
    * provided request configuration builder.
    *
    * @private
-   * @param {HttpRequestConfigBuilder} [requestConfigBuilder] request
+   * @param {HttpRequestBuilder} [requestConfigBuilder] request
    * configuration builder used to produce the request configuration
    * @return {Object<string, string>}
    */
@@ -197,7 +197,7 @@ class HttpClient {
    * configuration builder and default timeout.
    *
    * @private
-   * @param {HttpRequestConfigBuilder} [requestConfigBuilder] request
+   * @param {HttpRequestBuilder} [requestConfigBuilder] request
    * configuration builder used to produce the request configuration
    * @param {number} timeout default timeout if one is not specified in the
    * request config builder
@@ -205,7 +205,7 @@ class HttpClient {
    */
   getRequestConfig(requestConfigBuilder, timeout) {
     requestConfigBuilder = requestConfigBuilder ||
-      new HttpRequestConfigBuilder();
+      new HttpRequestBuilder();
 
     this.addXRequestIdHeader(requestConfigBuilder);
     this.addDefaultTimeout(requestConfigBuilder, timeout);

--- a/src/http/http-request-builder.js
+++ b/src/http/http-request-builder.js
@@ -17,6 +17,50 @@ class HttpRequestBuilder {
   }
 
   /**
+   * Prepares new builder for HTTP GET request against the provided URL.
+   *
+   * @static
+   * @param {string} url
+   * @return {HttpRequestBuilder}
+   */
+  static httpGet(url) {
+    return new HttpRequestBuilder().setMethod('get').setUrl(url);
+  }
+
+  /**
+   * Prepares new builder for HTTP POST request against the provided URL.
+   *
+   * @static
+   * @param {string} url
+   * @return {HttpRequestBuilder}
+   */
+  static httpPost(url) {
+    return new HttpRequestBuilder().setMethod('post').setUrl(url);
+  }
+
+  /**
+   * Prepares new builder for HTTP PUT request against the provided URL.
+   *
+   * @static
+   * @param {string} url
+   * @return {HttpRequestBuilder}
+   */
+  static httpPut(url) {
+    return new HttpRequestBuilder().setMethod('put').setUrl(url);
+  }
+
+  /**
+   * Prepares new builder for HTTP DELETE request against the provided URL.
+   *
+   * @static
+   * @param {string} url
+   * @return {HttpRequestBuilder}
+   */
+  static httpDelete(url) {
+    return new HttpRequestBuilder().setMethod('delete').setUrl(url);
+  }
+
+  /**
    * Add a new http header entry. Blank values are skipped.
    *
    * @param {string} header type
@@ -142,6 +186,75 @@ class HttpRequestBuilder {
   setResponseType(responseType) {
     this.config.responseType = responseType;
     return this;
+  }
+
+  /**
+   * Returns the request's response type.
+   *
+   * @return {string}
+   */
+  getResponseType() {
+    return this.config.responseType;
+  }
+
+  /**
+   * Sets the data to be sent as request payload.
+   *
+   * @param {*} data the payload
+   * @return {HttpRequestBuilder}
+   */
+  setData(data) {
+    this.config.data = data;
+    return this;
+  }
+
+  /**
+   * Gets the data to be sent as payload.
+   *
+   * @return {*}
+   */
+  getData() {
+    return this.config.data;
+  }
+
+  /**
+   * Sets the URL against which to perform the request.
+   *
+   * @param {string} url
+   * @return {HttpRequestBuilder}
+   */
+  setUrl(url) {
+    this.config.url = url;
+    return this;
+  }
+
+  /**
+   * Gets the URL.
+   *
+   * @return {string}
+   */
+  getUrl() {
+    return this.config.url;
+  }
+
+  /**
+   * Sets the HTTP method.
+   *
+   * @param {string} method
+   * @return {HttpRequestBuilder}
+   */
+  setMethod(method) {
+    this.config.method = method;
+    return this;
+  }
+
+  /**
+   * Gets the HTTP method.
+   *
+   * @return {string}
+   */
+  getMethod() {
+    return this.config.method;
   }
 
   /**

--- a/src/http/http-request-builder.js
+++ b/src/http/http-request-builder.js
@@ -1,14 +1,14 @@
 const StringUtils = require('../util/string-utils');
 
 /**
- * Holds request configuration applicable to the http client.
+ * Holds request information applicable to {@link HttpClient}.
  *
  * @class
  *
  * @author Mihail Radkov
  * @author Svilen Velikov
  */
-class HttpRequestConfigBuilder {
+class HttpRequestBuilder {
   /**
    * Does default initialization of the configuration.
    */
@@ -21,7 +21,7 @@ class HttpRequestConfigBuilder {
    *
    * @param {string} header type
    * @param {string} value the header value
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   addHeader(header, value) {
     if (StringUtils.isBlank(value)) {
@@ -38,7 +38,7 @@ class HttpRequestConfigBuilder {
    * Sets the headers map.
    *
    * @param {Object<string, string>} headers the headers map
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   setHeaders(headers) {
     this.config.headers = headers;
@@ -58,7 +58,7 @@ class HttpRequestConfigBuilder {
    * Add a specific header of type <code>Accept</code> with the given value.
    *
    * @param {string} value
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   addAcceptHeader(value) {
     return this.addHeader('Accept', value);
@@ -69,7 +69,7 @@ class HttpRequestConfigBuilder {
    * value.
    *
    * @param {string} value
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   addContentTypeHeader(value) {
     return this.addHeader('Content-Type', value);
@@ -79,7 +79,7 @@ class HttpRequestConfigBuilder {
    * Set request parameters object.
    *
    * @param {Object} params
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   setParams(params) {
     this.config.params = params;
@@ -91,7 +91,7 @@ class HttpRequestConfigBuilder {
    *
    * @param {string} param
    * @param {*} value
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   addParam(param, value) {
     if (!value) {
@@ -117,7 +117,7 @@ class HttpRequestConfigBuilder {
    * Set timeout configuration.
    *
    * @param {number} timeout in ms
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   setTimeout(timeout) {
     this.config.timeout = timeout;
@@ -137,7 +137,7 @@ class HttpRequestConfigBuilder {
    * Set a responseType config.
    *
    * @param {string} responseType
-   * @return {HttpRequestConfigBuilder}
+   * @return {HttpRequestBuilder}
    */
   setResponseType(responseType) {
     this.config.responseType = responseType;
@@ -153,4 +153,4 @@ class HttpRequestConfigBuilder {
   }
 }
 
-module.exports = HttpRequestConfigBuilder;
+module.exports = HttpRequestBuilder;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 module.exports = {
   http: {
     HttpClient: require('./http/http-client'),
-    HttpRequestConfigBuilder: require('./http/http-request-config-builder'),
+    HttpRequestBuilder: require('./http/http-request-builder'),
     QueryContentType: require('./http/query-content-type'),
     RDFMimeType: require('./http/rdf-mime-type')
   },

--- a/src/repository/rdf-repository-client.js
+++ b/src/repository/rdf-repository-client.js
@@ -10,7 +10,7 @@ const RepositoryClientConfig =
   require('../repository/repository-client-config');
 const TransactionalRepositoryClient =
   require('../transaction/transactional-repository-client');
-const HttpRequestConfigBuilder = require('../http/http-request-config-builder');
+const HttpRequestBuilder = require('../http/http-request-builder');
 const DataFactory = require('n3').DataFactory;
 const NamedNode = DataFactory.internal.NamedNode;
 
@@ -66,7 +66,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    *                           statements in the repository
    */
   getSize(context) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addParam('context', TermConverter.toNTripleValues(context));
 
     return this.execute((http) => http.get('/size', requestConfig))
@@ -84,7 +84,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    *                                {@link Namespace}
    */
   getNamespaces() {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addAcceptHeader(RDFMimeType.SPARQL_RESULTS_JSON);
 
     return this.execute((http) => http.get(PATH_NAMESPACES, requestConfig))
@@ -219,7 +219,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    *      to provided response type.
    */
   get(payload) {
-    const reqConfig = new HttpRequestConfigBuilder()
+    const reqConfig = new HttpRequestBuilder()
       .setParams({
         subj: TermConverter.toNTripleValue(payload.getSubject()),
         pred: TermConverter.toNTripleValue(payload.getPredicate()),
@@ -258,7 +258,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    * soon as they are available.
    */
   query(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setResponseType('stream')
       .addAcceptHeader(payload.getResponseType())
       .addContentTypeHeader(payload.getContentType());
@@ -293,7 +293,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    * successful or rejected in case of failure
    */
   update(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addContentTypeHeader(payload.getContentType());
 
     return this.execute((http) => http.post(PATH_STATEMENTS,
@@ -415,7 +415,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
       throw new Error('Turtle/trig data is required when adding statements');
     }
 
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addContentTypeHeader(RDFMimeType.TRIG)
       .setParams({
         baseURI,
@@ -450,7 +450,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    *                         successful or rejected in case of failure
    */
   deleteStatements(subject, predicate, object, contexts) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setParams({
         subj: TermConverter.toNTripleValue(subject),
         pred: TermConverter.toNTripleValue(predicate),
@@ -499,7 +499,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    * response type as soon as they are available.
    */
   download(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addAcceptHeader(payload.getResponseType())
       .setResponseType('stream')
       .setParams({
@@ -652,7 +652,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    * the stream has been successfully consumed by the server
    */
   uploadData(readStream, contentType, context, baseURI) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addContentTypeHeader(contentType)
       .setResponseType('stream')
       .setParams({
@@ -680,7 +680,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    * the stream has been successfully consumed by the server
    */
   overwriteData(readStream, contentType, context, baseURI) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addContentTypeHeader(contentType)
       .setResponseType('stream')
       .setParams({
@@ -707,7 +707,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    * @return {Promise<TransactionalRepositoryClient>} transactional client
    */
   beginTransaction(isolationLevel) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addParam('isolation-level', isolationLevel);
     return this.execute((http) => http.post('/transactions', requestConfig))
       .then((response) => {

--- a/src/repository/rdf-repository-client.js
+++ b/src/repository/rdf-repository-client.js
@@ -756,9 +756,12 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    */
   getTransactionalClientConfig(locationUrl) {
     const config = this.repositoryClientConfig;
-    return new RepositoryClientConfig([locationUrl], config.getHeaders(),
-      config.getDefaultRDFMimeType(), config.getReadTimeout(),
-      config.getWriteTimeout());
+    return new RepositoryClientConfig()
+      .setEndpoints([locationUrl])
+      .setHeaders(config.getHeaders())
+      .setDefaultRDFMimeType(config.getDefaultRDFMimeType())
+      .setReadTimeout(config.getReadTimeout())
+      .setWriteTimeout(config.getWriteTimeout());
   }
 }
 

--- a/src/server/server-client.js
+++ b/src/server/server-client.js
@@ -3,7 +3,7 @@ const ConsoleLogger = require('../logging/console-logger');
 const RDFRepositoryClient = require('../repository/rdf-repository-client');
 const RepositoryClientConfig =
   require('../repository/repository-client-config');
-const HttpRequestConfigBuilder = require('../http/http-request-config-builder');
+const HttpRequestBuilder = require('../http/http-request-builder');
 const RDFMimeType = require('../http/rdf-mime-type');
 
 const SERVICE_URL = '/repositories';
@@ -31,7 +31,7 @@ class ServerClient {
    * @return {Promise} promise which resolves with an Array with repository ids.
    */
   getRepositoryIDs() {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addAcceptHeader(RDFMimeType.SPARQL_RESULTS_JSON);
 
     let elapsedTime = Date.now();

--- a/src/server/server-client.js
+++ b/src/server/server-client.js
@@ -31,11 +31,11 @@ class ServerClient {
    * @return {Promise} promise which resolves with an Array with repository ids.
    */
   getRepositoryIDs() {
-    const requestConfig = new HttpRequestBuilder()
+    const requestBuilder = HttpRequestBuilder.httpGet(SERVICE_URL)
       .addAcceptHeader(RDFMimeType.SPARQL_RESULTS_JSON);
 
     let elapsedTime = Date.now();
-    return this.httpClient.get(SERVICE_URL, requestConfig).then((response) => {
+    return this.httpClient.request(requestBuilder).then((response) => {
       elapsedTime = Date.now() - elapsedTime;
       this.logger.debug({elapsedTime}, 'Retrieved repository IDs');
       return response.data.results.bindings.map(({id}) => id.value);
@@ -92,12 +92,14 @@ class ServerClient {
       throw new Error('Repository id is required parameter!');
     }
 
+    const requestBuilder = HttpRequestBuilder
+      .httpDelete(`${SERVICE_URL}/${id}`);
+
     let elapsedTime = Date.now();
-    return this.httpClient.deleteResource(`${SERVICE_URL}/${id}`)
-      .then(() => {
-        elapsedTime = Date.now() - elapsedTime;
-        this.logger.info({repoId: id, elapsedTime}, 'Deleted repository');
-      });
+    return this.httpClient.request(requestBuilder).then(() => {
+      elapsedTime = Date.now() - elapsedTime;
+      this.logger.info({repoId: id, elapsedTime}, 'Deleted repository');
+    });
   }
 
   /**

--- a/src/transaction/transactional-repository-client.js
+++ b/src/transaction/transactional-repository-client.js
@@ -5,7 +5,7 @@ const TermConverter = require('../model/term-converter');
 const StringUtils = require('../util/string-utils');
 const FileUtils = require('../util/file-utils');
 const CommonUtils = require('../util/common-utils');
-const HttpRequestConfigBuilder = require('../http/http-request-config-builder');
+const HttpRequestBuilder = require('../http/http-request-builder');
 
 /**
  * Transactional RDF repository client implementation realizing transaction
@@ -63,7 +63,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    * @return {Promise<number>} a promise resolving to the size of the repo
    */
   getSize(context) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setParams({
         action: 'SIZE',
         context: TermConverter.toNTripleValues(context)
@@ -91,7 +91,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    *      to provided response type.
    */
   get(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setParams({
         action: 'GET',
         subj: TermConverter.toNTripleValue(payload.getSubject()),
@@ -129,7 +129,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    * soon as they are available.
    */
   query(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setResponseType('stream')
       .addAcceptHeader(payload.getResponseType())
       .addContentTypeHeader(payload.getContentType())
@@ -158,7 +158,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    * successful or rejected in case of failure
    */
   update(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addContentTypeHeader(payload.getContentType())
       .setParams({
         action: 'UPDATE'
@@ -251,7 +251,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       throw new Error('Turtle data is required when adding statements');
     }
 
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setParams({
         action: 'ADD',
         context: TermConverter.toNTripleValues(context),
@@ -282,7 +282,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       throw new Error('Turtle data is required when deleting statements');
     }
 
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setParams({
         action: 'DELETE'
       })
@@ -310,7 +310,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    * response type as soon as they are available.
    */
   download(payload) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addAcceptHeader(payload.getResponseType())
       .setResponseType('stream')
       .setParams({
@@ -408,7 +408,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    * the stream has been successfully consumed by the server
    */
   uploadData(readStream, contentType, context, baseURI) {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .addContentTypeHeader(contentType)
       .setResponseType('stream')
       .setParams({
@@ -429,7 +429,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    * @return {Promise<void>} that will be resolved after successful commit
    */
   commit() {
-    const requestConfig = new HttpRequestConfigBuilder()
+    const requestConfig = new HttpRequestBuilder()
       .setParams({
         action: 'COMMIT'
       });

--- a/test/http/http-client.spec.js
+++ b/test/http/http-client.spec.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const HttpClient = require('http/http-client');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
 jest.mock('axios');
 
@@ -36,7 +36,7 @@ describe('HttpClient', () => {
     axiosMock.put.mockResolvedValue();
     axiosMock.delete.mockResolvedValue();
 
-    requestConfig = new HttpRequestConfigBuilder().setParams({
+    requestConfig = new HttpRequestBuilder().setParams({
       'param-1': 'value-1'
     }).setHeaders({
       'Accept': 'application/json'

--- a/test/http/http-client.stub.js
+++ b/test/http/http-client.stub.js
@@ -7,10 +7,7 @@ function stub(baseUrl) {
     setDefaultHeaders: jest.fn().mockReturnThis(),
     setDefaultReadTimeout: jest.fn().mockReturnThis(),
     setDefaultWriteTimeout: jest.fn().mockReturnThis(),
-    get: jest.fn().mockResolvedValue({}),
-    post: jest.fn().mockResolvedValue({}),
-    put: jest.fn().mockResolvedValue({}),
-    deleteResource: jest.fn().mockResolvedValue({}),
+    request: jest.fn().mockResolvedValue({}),
     getBaseURL: () => baseUrl
   };
 }

--- a/test/http/http-request-builder.spec.js
+++ b/test/http/http-request-builder.spec.js
@@ -5,6 +5,28 @@ describe('HttpRequestBuilder', () => {
     expect(new HttpRequestBuilder().get()).toEqual({});
   });
 
+  test('should assign request with HTTP method and URL', () => {
+    let builder = new HttpRequestBuilder();
+    expect(builder.getMethod()).toBeUndefined();
+    expect(builder.getUrl()).toBeUndefined();
+
+    builder = HttpRequestBuilder.httpGet('/get');
+    expect(builder.getMethod()).toEqual('get');
+    expect(builder.getUrl()).toEqual('/get');
+
+    builder = HttpRequestBuilder.httpPost('/post');
+    expect(builder.getMethod()).toEqual('post');
+    expect(builder.getUrl()).toEqual('/post');
+
+    builder = HttpRequestBuilder.httpPut('/put');
+    expect(builder.getMethod()).toEqual('put');
+    expect(builder.getUrl()).toEqual('/put');
+
+    builder = HttpRequestBuilder.httpDelete('/delete');
+    expect(builder.getMethod()).toEqual('delete');
+    expect(builder.getUrl()).toEqual('/delete');
+  });
+
   test('should add a header in headers map', () => {
     expect(new HttpRequestBuilder()
       .addHeader('Accept', 'text/turtle')
@@ -53,7 +75,6 @@ describe('HttpRequestBuilder', () => {
       });
   });
 
-
   test('should should set timeout configuration', () => {
     expect(new HttpRequestBuilder()
       .setTimeout(1000)
@@ -77,6 +98,13 @@ describe('HttpRequestBuilder', () => {
       .toEqual({
         responseType: 'stream'
       });
+  });
+
+  test('should get the response type configuration', () => {
+    expect(new HttpRequestBuilder()
+      .setResponseType('stream')
+      .getResponseType())
+      .toEqual('stream');
   });
 
   test('should add Accept header', () => {
@@ -112,6 +140,33 @@ describe('HttpRequestBuilder', () => {
       .getHeaders())
       .toEqual({
         'Content-Type': 'text/turtle'
+      });
+  });
+
+  test('should set HTTP method', () => {
+    expect(new HttpRequestBuilder()
+      .setMethod('get')
+      .get())
+      .toEqual({
+        method: 'get'
+      });
+  });
+
+  test('should set request URL', () => {
+    expect(new HttpRequestBuilder()
+      .setUrl('/service')
+      .get())
+      .toEqual({
+        url: '/service'
+      });
+  });
+
+  test('should set data payload', () => {
+    expect(new HttpRequestBuilder()
+      .setData('some text data')
+      .get())
+      .toEqual({
+        data: 'some text data'
       });
   });
 });

--- a/test/http/http-request-builder.spec.js
+++ b/test/http/http-request-builder.spec.js
@@ -1,12 +1,12 @@
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
-describe('HttpRequestConfigBuilder', () => {
+describe('HttpRequestBuilder', () => {
   test('should init with an empty config', () => {
-    expect(new HttpRequestConfigBuilder().get()).toEqual({});
+    expect(new HttpRequestBuilder().get()).toEqual({});
   });
 
   test('should add a header in headers map', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .addHeader('Accept', 'text/turtle')
       .get())
       .toEqual({
@@ -15,7 +15,7 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should set params provided as argument in the config', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .setParams({
         subj: 'subj',
         pred: 'pred'
@@ -30,7 +30,7 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should add param in the params mapping', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .addParam('subj', 'subj')
       .addParam('pred', 'pred')
       .get())
@@ -43,7 +43,7 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should get the params mapping', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .addParam('subj', 'subj')
       .addParam('pred', 'pred')
       .getParams())
@@ -55,7 +55,7 @@ describe('HttpRequestConfigBuilder', () => {
 
 
   test('should should set timeout configuration', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .setTimeout(1000)
       .get())
       .toEqual({
@@ -64,14 +64,14 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should get the timeout configuration', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .setTimeout(1000)
       .getTimeout())
       .toEqual(1000);
   });
 
   test('should should set response type configuration', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .setResponseType('stream')
       .get())
       .toEqual({
@@ -80,7 +80,7 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should add Accept header', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .addAcceptHeader('text/turtle')
       .get())
       .toEqual({
@@ -89,7 +89,7 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should add Content-Type header', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .addContentTypeHeader('text/turtle')
       .get())
       .toEqual({
@@ -98,7 +98,7 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should skip empty header values', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .addContentTypeHeader('')
       .addAcceptHeader()
       .addHeader('custom', null)
@@ -107,7 +107,7 @@ describe('HttpRequestConfigBuilder', () => {
   });
 
   test('should get the headers', () => {
-    expect(new HttpRequestConfigBuilder()
+    expect(new HttpRequestBuilder()
       .addContentTypeHeader('text/turtle')
       .getHeaders())
       .toEqual({

--- a/test/repository/base-repository-client-failover.spec.js
+++ b/test/repository/base-repository-client-failover.spec.js
@@ -37,10 +37,10 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClient(httpClient3, 200);
 
-      return repositoryClient.execute((client) => client.get('url')).then(() => {
-        expect(httpClient1.get).toHaveBeenCalledTimes(1);
-        expect(httpClient2.get).toHaveBeenCalledTimes(1);
-        expect(httpClient3.get).toHaveBeenCalledTimes(1);
+      return repositoryClient.execute((client) => client.request('url')).then(() => {
+        expect(httpClient1.request).toHaveBeenCalledTimes(1);
+        expect(httpClient2.request).toHaveBeenCalledTimes(1);
+        expect(httpClient3.request).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -54,10 +54,10 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClient(httpClient3, 503);
 
-      return repositoryClient.execute((client) => client.get('url')).catch(() => {
-        expect(httpClient1.get).toHaveBeenCalledTimes(1);
-        expect(httpClient2.get).toHaveBeenCalledTimes(1);
-        expect(httpClient3.get).toHaveBeenCalledTimes(1);
+      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+        expect(httpClient1.request).toHaveBeenCalledTimes(1);
+        expect(httpClient2.request).toHaveBeenCalledTimes(1);
+        expect(httpClient3.request).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -72,10 +72,10 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClient(httpClient3, 200);
 
-      return repositoryClient.execute((client) => client.get('url')).then(() => {
-        expect(httpClient1.get).toHaveBeenCalledTimes(1);
-        expect(httpClient2.get).toHaveBeenCalledTimes(1);
-        expect(httpClient3.get).toHaveBeenCalledTimes(1);
+      return repositoryClient.execute((client) => client.request('url')).then(() => {
+        expect(httpClient1.request).toHaveBeenCalledTimes(1);
+        expect(httpClient2.request).toHaveBeenCalledTimes(1);
+        expect(httpClient3.request).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -90,53 +90,58 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClientWithoutResponse(httpClient3);
 
-      return repositoryClient.execute((client) => client.get('url')).catch(() => {
-        expect(httpClient1.get).toHaveBeenCalledTimes(1);
-        expect(httpClient2.get).toHaveBeenCalledTimes(1);
-        expect(httpClient3.get).toHaveBeenCalledTimes(1);
+      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+        expect(httpClient1.request).toHaveBeenCalledTimes(1);
+        expect(httpClient2.request).toHaveBeenCalledTimes(1);
+        expect(httpClient3.request).toHaveBeenCalledTimes(1);
       });
     });
 
     test('should reject if the error is not from the HTTP request', () => {
       //
       let httpClient1 = repositoryClient.httpClients[0];
-      httpClient1.get.mockRejectedValue(new Error('Error before/after request'));
+      httpClient1.request.mockRejectedValue(new Error('Error before/after request'));
 
       let httpClient2 = repositoryClient.httpClients[1];
       let httpClient3 = repositoryClient.httpClients[2];
 
-      return repositoryClient.execute((client) => client.get('url')).catch(() => {
-        expect(httpClient1.get).toHaveBeenCalledTimes(1);
-        expect(httpClient2.get).toHaveBeenCalledTimes(0);
-        expect(httpClient3.get).toHaveBeenCalledTimes(0);
+      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+        expect(httpClient1.request).toHaveBeenCalledTimes(1);
+        expect(httpClient2.request).toHaveBeenCalledTimes(0);
+        expect(httpClient3.request).toHaveBeenCalledTimes(0);
       });
     });
 
     test('should reject if there is no provided error', () => {
       // No error/response
       let httpClient1 = repositoryClient.httpClients[0];
-      httpClient1.get.mockRejectedValue();
+      httpClient1.request.mockRejectedValue();
 
       let httpClient2 = repositoryClient.httpClients[1];
       let httpClient3 = repositoryClient.httpClients[2];
 
-      return repositoryClient.execute((client) => client.get('url')).catch(() => {
-        expect(httpClient1.get).toHaveBeenCalledTimes(1);
-        expect(httpClient2.get).toHaveBeenCalledTimes(0);
-        expect(httpClient3.get).toHaveBeenCalledTimes(0);
+      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+        expect(httpClient1.request).toHaveBeenCalledTimes(1);
+        expect(httpClient2.request).toHaveBeenCalledTimes(0);
+        expect(httpClient3.request).toHaveBeenCalledTimes(0);
       });
+    });
+
+    it('should reject if it cannot properly execute requests', () => {
+      // Not providing a consumer function should cause the client blow and reject
+      expect(repositoryClient.execute()).rejects.toEqual(Error);
     });
   });
 
   function stubHttpClient(client, status) {
-    client.get = jest.fn();
+    client.request = jest.fn();
     if (status < 400) {
-      client.get.mockResolvedValueOnce({
+      client.request.mockResolvedValueOnce({
         request: {},
         status
       });
     } else {
-      client.get.mockRejectedValueOnce({
+      client.request.mockRejectedValueOnce({
         request: {},
         response: {status}
       });
@@ -144,7 +149,7 @@ describe('BaseRepositoryClient', () => {
   }
 
   function stubHttpClientWithoutResponse(client) {
-    client.get.mockRejectedValue({
+    client.request.mockRejectedValue({
       request: {}
     });
   }

--- a/test/repository/rdf-repository-client-adding-data.spec.js
+++ b/test/repository/rdf-repository-client-adding-data.spec.js
@@ -12,7 +12,6 @@ const {namedNode, literal, quad} = DataFactory;
 
 const httpClientStub = require('../http/http-client.stub');
 const testUtils = require('../utils');
-const {when} = require('jest-when');
 
 jest.mock('http/http-client');
 
@@ -192,7 +191,7 @@ describe('RDFRepositoryClient - adding data', () => {
     });
 
     test('should reject adding the payload when the server request is unsuccessful', () => {
-      rdfRepositoryClient.httpClients[0].post.mockRejectedValue({});
+      rdfRepositoryClient.httpClients[0].request.mockRejectedValue({});
       const payload = new AddStatementPayload()
         .setSubject(subj('resource-1'))
         .setPredicate(pred('relation-1'))
@@ -233,7 +232,7 @@ describe('RDFRepositoryClient - adding data', () => {
     });
 
     test('should reject adding quads when the server request is unsuccessful', () => {
-      when(rdfRepositoryClient.httpClients[0].post).calledWith('/statements').mockRejectedValue('error-adding');
+      rdfRepositoryClient.httpClients[0].request.mockRejectedValue('error-adding');
       const quads = [getQuad('resource-1', 'relation-1', 'uri-1')];
       return expect(rdfRepositoryClient.addQuads(quads)).rejects.toEqual('error-adding');
     });
@@ -265,36 +264,40 @@ describe('RDFRepositoryClient - adding data', () => {
     });
 
     test('should reject putting quads when the server request is unsuccessful', () => {
-      when(rdfRepositoryClient.httpClients[0].put).calledWith('/statements').mockRejectedValue('error-overwriting');
+      rdfRepositoryClient.httpClients[0].request.mockRejectedValue('error-overwriting');
       const quads = [getQuad('resource-1', 'relation-1', 'uri-1')];
       return expect(rdfRepositoryClient.putQuads(quads)).rejects.toEqual('error-overwriting');
     });
   });
 
   function verifyAddPayload(expected, context, baseURI) {
-    const post = rdfRepositoryClient.httpClients[0].post;
-    verifySentPayload(post, expected, context, baseURI);
+    verifySentPayload('post', expected, context, baseURI);
   }
 
   function verifyPutPayload(expected, context, baseURI) {
-    const put = rdfRepositoryClient.httpClients[0].put;
-    verifySentPayload(put, expected, context, baseURI);
+    verifySentPayload('put', expected, context, baseURI);
   }
 
   function verifySentPayload(method, expected, context, baseURI) {
-    const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-      'Content-Type': RDFMimeType.TRIG
-    }).setParams({
-      context,
-      baseURI
-    });
-    expect(method).toHaveBeenCalledTimes(1);
-    expect(method).toHaveBeenCalledWith('/statements', expected, expectedRequestConfig);
+    const httpRequest = rdfRepositoryClient.httpClients[0].request;
+    const expectedRequestConfig = new HttpRequestBuilder()
+      .setMethod(method)
+      .setUrl('/statements')
+      .setData(expected)
+      .setHeaders({
+        'Content-Type': RDFMimeType.TRIG
+      })
+      .setParams({
+        context,
+        baseURI
+      });
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+    expect(httpRequest).toHaveBeenCalledWith(expectedRequestConfig);
   }
 
   function verifyNoPayload() {
-    const post = rdfRepositoryClient.httpClients[0].post;
-    expect(post).toHaveBeenCalledTimes(0);
+    const httpRequest = rdfRepositoryClient.httpClients[0].request;
+    expect(httpRequest).toHaveBeenCalledTimes(0);
   }
 
   function getQuadsDataSet() {

--- a/test/repository/rdf-repository-client-adding-data.spec.js
+++ b/test/repository/rdf-repository-client-adding-data.spec.js
@@ -4,7 +4,7 @@ const RDFRepositoryClient = require('repository/rdf-repository-client');
 const RDFMimeType = require('http/rdf-mime-type');
 const AddStatementPayload = require('repository/add-statement-payload');
 const XSD = require('model/types').XSD;
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
 const N3 = require('n3');
 const {DataFactory} = N3;
@@ -282,7 +282,7 @@ describe('RDFRepositoryClient - adding data', () => {
   }
 
   function verifySentPayload(method, expected, context, baseURI) {
-    const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+    const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
       'Content-Type': RDFMimeType.TRIG
     }).setParams({
       context,

--- a/test/repository/rdf-repository-client-deleting-data.spec.js
+++ b/test/repository/rdf-repository-client-deleting-data.spec.js
@@ -1,7 +1,7 @@
 const HttpClient = require('http/http-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const RDFRepositoryClient = require('repository/rdf-repository-client');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 const httpClientStub = require('../http/http-client.stub');
 const {when} = require('jest-when');
 
@@ -36,7 +36,7 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(subj).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
           subj, pred: undefined, obj: undefined, context: undefined
         }));
       });
@@ -46,7 +46,7 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(subj, pred, obj).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
           subj, pred, obj, context: undefined
         }));
       });
@@ -57,7 +57,7 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(subj, pred, obj, contexts).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
           subj, pred, obj, context: contexts
         }));
       });
@@ -67,7 +67,7 @@ describe('RDFRepositoryClient - Deleting statements', () => {
       return rdfRepositoryClient.deleteStatements(null, null, null, context).then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
           subj: undefined, pred: undefined, obj: undefined, context
         }));
       });
@@ -86,7 +86,7 @@ describe('RDFRepositoryClient - Deleting statements', () => {
         'http://domain/graph/1').then(() => {
         let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
         expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestConfigBuilder().setParams({
+        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
           subj, pred, obj, context
         }));
       });

--- a/test/repository/rdf-repository-client-deleting-data.spec.js
+++ b/test/repository/rdf-repository-client-deleting-data.spec.js
@@ -3,7 +3,6 @@ const RepositoryClientConfig = require('repository/repository-client-config');
 const RDFRepositoryClient = require('repository/rdf-repository-client');
 const HttpRequestBuilder = require('http/http-request-builder');
 const httpClientStub = require('../http/http-client.stub');
-const {when} = require('jest-when');
 
 jest.mock('http/http-client');
 
@@ -19,6 +18,7 @@ describe('RDFRepositoryClient - Deleting statements', () => {
 
   let repoClientConfig;
   let rdfRepositoryClient;
+  let httpRequest;
 
   beforeEach(() => {
     repoClientConfig = new RepositoryClientConfig()
@@ -29,14 +29,14 @@ describe('RDFRepositoryClient - Deleting statements', () => {
     HttpClient.mockImplementation(() => httpClientStub());
 
     rdfRepositoryClient = new RDFRepositoryClient(repoClientConfig);
+    httpRequest = rdfRepositoryClient.httpClients[0].request;
   });
 
   describe('deleteStatements(subject, predicate, object, contexts)', () => {
     test('should allow to delete all statements for given subject', () => {
       return rdfRepositoryClient.deleteStatements(subj).then(() => {
-        let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
-        expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpDelete('/statements').setParams({
           subj, pred: undefined, obj: undefined, context: undefined
         }));
       });
@@ -44,9 +44,8 @@ describe('RDFRepositoryClient - Deleting statements', () => {
 
     test('should allow to delete specific statement', () => {
       return rdfRepositoryClient.deleteStatements(subj, pred, obj).then(() => {
-        let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
-        expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpDelete('/statements').setParams({
           subj, pred, obj, context: undefined
         }));
       });
@@ -55,9 +54,8 @@ describe('RDFRepositoryClient - Deleting statements', () => {
     test('should allow to delete specific statements in specific graphs', () => {
       let contexts = [context, '<http://domain/graph/2>'];
       return rdfRepositoryClient.deleteStatements(subj, pred, obj, contexts).then(() => {
-        let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
-        expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpDelete('/statements').setParams({
           subj, pred, obj, context: contexts
         }));
       });
@@ -65,16 +63,15 @@ describe('RDFRepositoryClient - Deleting statements', () => {
 
     test('should allow to delete all statements from specific graph', () => {
       return rdfRepositoryClient.deleteStatements(null, null, null, context).then(() => {
-        let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
-        expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpDelete('/statements').setParams({
           subj: undefined, pred: undefined, obj: undefined, context
         }));
       });
     });
 
     test('should reject deleting statements when the server request is unsuccessful', () => {
-      when(rdfRepositoryClient.httpClients[0].deleteResource).calledWith('/statements').mockRejectedValue('error-deleting');
+      httpRequest.mockRejectedValue('error-deleting');
       return expect(rdfRepositoryClient.deleteStatements(subj)).rejects.toEqual('error-deleting');
     });
 
@@ -84,9 +81,8 @@ describe('RDFRepositoryClient - Deleting statements', () => {
         'http://domain/property/1',
         'http://domain/value/1',
         'http://domain/graph/1').then(() => {
-        let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
-        expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements', new HttpRequestBuilder().setParams({
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpDelete('/statements').setParams({
           subj, pred, obj, context
         }));
       });
@@ -100,14 +96,13 @@ describe('RDFRepositoryClient - Deleting statements', () => {
   describe('deleteAllStatements()', () => {
     test('should properly request all statements deletion', () => {
       return rdfRepositoryClient.deleteAllStatements().then(() => {
-        let deleteResource = rdfRepositoryClient.httpClients[0].deleteResource;
-        expect(deleteResource).toHaveBeenCalledTimes(1);
-        expect(deleteResource).toHaveBeenCalledWith('/statements');
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpDelete('/statements'));
       });
     });
 
     test('should reject deleting all statements when the server request is unsuccessful', () => {
-      when(rdfRepositoryClient.httpClients[0].deleteResource).calledWith('/statements').mockRejectedValue('error-deleting-all');
+      httpRequest.mockRejectedValue('error-deleting-all');
       return expect(rdfRepositoryClient.deleteAllStatements()).rejects.toEqual('error-deleting-all');
     });
 

--- a/test/repository/rdf-repository-client-namespaces.spec.js
+++ b/test/repository/rdf-repository-client-namespaces.spec.js
@@ -5,7 +5,7 @@ const RDFMimeType = require('http/rdf-mime-type');
 const DataFactory = require('n3').DataFactory;
 const NamedNode = DataFactory.internal.NamedNode;
 const Namespace = require('model/namespace');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 const httpClientStub = require('../http/http-client.stub');
 const namespaceData = require('./data/namespaces.json');
 
@@ -43,7 +43,7 @@ describe('RDFRepositoryClient - Namespace management', () => {
 
         let get = rdfRepositoryClient.httpClients[0].get;
         expect(get).toHaveBeenCalledTimes(1);
-        expect(get).toHaveBeenCalledWith('/namespaces', new HttpRequestConfigBuilder().setHeaders({
+        expect(get).toHaveBeenCalledWith('/namespaces', new HttpRequestBuilder().setHeaders({
           'Accept': RDFMimeType.SPARQL_RESULTS_JSON
         }));
       });

--- a/test/repository/rdf-repository-client-query.spec.js
+++ b/test/repository/rdf-repository-client-query.spec.js
@@ -10,7 +10,7 @@ const SparqlJsonResultParser = require('parser/sparql-json-result-parser');
 const SparqlXmlResultParser = require('parser/sparql-xml-result-parser');
 const DataFactory = require('n3').DataFactory;
 const namedNode = DataFactory.namedNode;
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
 const httpClientStub = require('../http/http-client.stub');
 
@@ -216,7 +216,7 @@ describe('RDFRepositoryClient - query', () => {
       .setTimeout(5);
 
     const expectedData = 'query=select%20*%20where%20%7B%3Fs%20%3Fp%20%3Fo%7D&queryLn=sparql&infer=true&distinct=true&limit=100&offset=0&timeout=5';
-    const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+    const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
       'Accept': 'application/sparql-results+json',
       'Content-Type': 'application/x-www-form-urlencoded'
     }).setResponseType('stream');

--- a/test/repository/rdf-repository-client-query.spec.js
+++ b/test/repository/rdf-repository-client-query.spec.js
@@ -21,6 +21,7 @@ jest.mock('http/http-client');
 describe('RDFRepositoryClient - query', () => {
   let config;
   let repository;
+  let httpRequest;
 
   beforeEach(() => {
     HttpClient.mockImplementation(() => httpClientStub());
@@ -29,6 +30,7 @@ describe('RDFRepositoryClient - query', () => {
       .setReadTimeout(1000)
       .setWriteTimeout(1000);
     repository = new RDFRepositoryClient(config);
+    httpRequest = repository.httpClients[0].request;
   });
 
   describe('should execute query and stream the result', () => {
@@ -42,7 +44,7 @@ describe('RDFRepositoryClient - query', () => {
       reader = new ObjectReadableMock(source);
       expected = expectedStream();
       expectedIt = expected[Symbol.iterator]();
-      repository.httpClients[0].post.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: reader
       });
     });
@@ -114,7 +116,7 @@ describe('RDFRepositoryClient - query', () => {
       const reader = new ObjectReadableMock(source);
       const expected = expectedParsedStream();
       const expectedIt = expected[Symbol.iterator]();
-      repository.httpClients[0].post.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: reader
       });
 
@@ -137,7 +139,7 @@ describe('RDFRepositoryClient - query', () => {
     test('xml boolean result', (done) => {
       const source = [data.ask.xml];
       const reader = new ObjectReadableMock(source);
-      repository.httpClients[0].post.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: reader
       });
 
@@ -160,7 +162,7 @@ describe('RDFRepositoryClient - query', () => {
       const reader = new ObjectReadableMock(source);
       const expected = expectedParsedStream();
       const expectedIt = expected[Symbol.iterator]();
-      repository.httpClients[0].post.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: reader
       });
 
@@ -183,7 +185,7 @@ describe('RDFRepositoryClient - query', () => {
     test('json boolean result', (done) => {
       const source = [data.ask.json];
       const reader = new ObjectReadableMock(source);
-      repository.httpClients[0].post.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: reader
       });
 
@@ -202,8 +204,6 @@ describe('RDFRepositoryClient - query', () => {
   });
 
   test('should make a POST request with proper parameters and headers', () => {
-    const postMock = repository.httpClients[0].post;
-
     const payload = new GetQueryPayload()
       .setQuery('select * where {?s ?p ?o}')
       .setQueryType(QueryType.SELECT)
@@ -216,14 +216,17 @@ describe('RDFRepositoryClient - query', () => {
       .setTimeout(5);
 
     const expectedData = 'query=select%20*%20where%20%7B%3Fs%20%3Fp%20%3Fo%7D&queryLn=sparql&infer=true&distinct=true&limit=100&offset=0&timeout=5';
-    const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-      'Accept': 'application/sparql-results+json',
-      'Content-Type': 'application/x-www-form-urlencoded'
-    }).setResponseType('stream');
+    const expectedRequestConfig = HttpRequestBuilder.httpPost('')
+      .setData(expectedData)
+      .setHeaders({
+        'Accept': 'application/sparql-results+json',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      })
+      .setResponseType('stream');
 
     return repository.query(payload).then(() => {
-      expect(postMock).toHaveBeenCalledTimes(1);
-      expect(postMock).toHaveBeenCalledWith('', expectedData, expectedRequestConfig);
+      expect(httpRequest).toHaveBeenCalledTimes(1);
+      expect(httpRequest).toHaveBeenCalledWith(expectedRequestConfig);
     });
   });
 
@@ -234,7 +237,7 @@ describe('RDFRepositoryClient - query', () => {
         .setQueryType(QueryType.SELECT)
         .setResponseType(RDFMimeType.RDF_XML);
 
-      return expect(repository.query(payload)).rejects.toBeTruthy();
+      return expect(() => repository.query(payload)).toThrow(Error);
     });
 
     test('should throw error if responseType is not properly configured for DESCRIBE query', () => {
@@ -243,7 +246,7 @@ describe('RDFRepositoryClient - query', () => {
         .setQueryType(QueryType.DESCRIBE)
         .setResponseType(RDFMimeType.SPARQL_RESULTS_JSON);
 
-      return expect(repository.query(payload)).rejects.toBeTruthy();
+      return expect(() => repository.query(payload)).toThrow(Error);
     });
 
     test('should throw error if responseType is not properly configured for CONSTRUCT query', () => {
@@ -252,7 +255,7 @@ describe('RDFRepositoryClient - query', () => {
         .setQueryType(QueryType.CONSTRUCT)
         .setResponseType(RDFMimeType.SPARQL_RESULTS_JSON);
 
-      return expect(repository.query(payload)).rejects.toBeTruthy();
+      return expect(() => repository.query(payload)).toThrow(Error);
     });
 
     test('should throw error if responseType is not properly configured for ASK query', () => {
@@ -261,7 +264,7 @@ describe('RDFRepositoryClient - query', () => {
         .setQueryType(QueryType.ASK)
         .setResponseType(RDFMimeType.BINARY_RDF);
 
-      return expect(repository.query(payload)).rejects.toBeTruthy();
+      return expect(() => repository.query(payload)).toThrow(Error);
     });
   });
 

--- a/test/repository/rdf-repository-client-reading-data.spec.js
+++ b/test/repository/rdf-repository-client-reading-data.spec.js
@@ -8,7 +8,7 @@ const NTriplesParser = require('parser/n-triples-parser');
 const NQuadsParser = require('parser/n-quads-parser');
 const N3Parser = require('parser/n3-parser');
 const TriGParser = require('parser/trig-parser');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 const JsonLDParser = require('parser/jsonld-parser');
 const RDFXmlParser = require('parser/rdfxml-parser');
 
@@ -206,7 +206,7 @@ describe('RDFRepositoryClient - reading statements', () => {
     });
 
     function verifyGetRequest() {
-      const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
         'Accept': RDFMimeType.RDF_JSON
       }).setParams({
         infer: true,
@@ -309,7 +309,7 @@ describe('RDFRepositoryClient - reading statements', () => {
     });
 
     function verifyDownloadRequest(getMock) {
-      const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
         'Accept': 'text/turtle'
       }).setParams({
         subj: '<http://eunis.eea.europa.eu/countries/AZ>',

--- a/test/repository/rdf-repository-client-reading-data.spec.js
+++ b/test/repository/rdf-repository-client-reading-data.spec.js
@@ -34,16 +34,19 @@ const jsonldDataFile = path.resolve(__dirname, './data/read-statements-jsonld.tx
 const rdfxmlDataFile = path.resolve(__dirname, './data/read-statements-rdfxml.txt');
 
 describe('RDFRepositoryClient - reading statements', () => {
+
   let config;
   let repository;
-  const endpoints = ['http://host/repositories/repo1'];
-  const headers = {};
-  const contentType = '';
-  const readTimeout = 1000;
-  const writeTimeout = 1000;
+  let httpRequest;
 
   beforeEach(() => {
     HttpClient.mockImplementation(() => httpClientStub());
+
+    const endpoints = ['http://host/repositories/repo1'];
+    const headers = {};
+    const contentType = '';
+    const readTimeout = 1000;
+    const writeTimeout = 1000;
 
     config = new RepositoryClientConfig()
       .setEndpoints(endpoints)
@@ -52,6 +55,7 @@ describe('RDFRepositoryClient - reading statements', () => {
       .setReadTimeout(readTimeout)
       .setWriteTimeout(writeTimeout);
     repository = new RDFRepositoryClient(config);
+    httpRequest = repository.httpClients[0].request;
   });
 
   describe('statements#get returning Quads', () => {
@@ -61,10 +65,10 @@ describe('RDFRepositoryClient - reading statements', () => {
       literal(7931000),
       defaultGraph())];
 
-    function mockHttpGET(type) {
-      repository.httpClients[0].get.mockImplementation(() => Promise.resolve({
+    function mockHttpRequest(type) {
+      httpRequest.mockResolvedValue({
         data: data.repositories.repo1.statements.GET[type]
-      }));
+      });
     }
 
     function buildPayload(type) {
@@ -77,7 +81,7 @@ describe('RDFRepositoryClient - reading statements', () => {
     test('should fetch statement in N-Triples format and return it converted to quads', () => {
       repository.registerParser(new NTriplesParser());
 
-      mockHttpGET(RDFMimeType.N_TRIPLES);
+      mockHttpRequest(RDFMimeType.N_TRIPLES);
 
       const payload = buildPayload(RDFMimeType.N_TRIPLES);
       return expect(repository.get(payload)).resolves.toEqual(expected);
@@ -86,7 +90,7 @@ describe('RDFRepositoryClient - reading statements', () => {
     test('should fetch statement in N3 format and return it converted to quads', () => {
       repository.registerParser(new N3Parser());
 
-      mockHttpGET(RDFMimeType.N3);
+      mockHttpRequest(RDFMimeType.N3);
 
       const payload = buildPayload(RDFMimeType.N3);
       return expect(repository.get(payload)).resolves.toEqual(expected);
@@ -95,7 +99,7 @@ describe('RDFRepositoryClient - reading statements', () => {
     test('should fetch statement in TriG format and return it converted to quads', () => {
       repository.registerParser(new TriGParser());
 
-      mockHttpGET(RDFMimeType.TRIG);
+      mockHttpRequest(RDFMimeType.TRIG);
 
       const payload = buildPayload(RDFMimeType.TRIG);
       return expect(repository.get(payload)).resolves.toEqual(expected);
@@ -104,7 +108,7 @@ describe('RDFRepositoryClient - reading statements', () => {
     test('should fetch statement in N-Quads format and return it converted to quads', () => {
       repository.registerParser(new NQuadsParser());
 
-      mockHttpGET(RDFMimeType.N_QUADS);
+      mockHttpRequest(RDFMimeType.N_QUADS);
 
       const payload = buildPayload(RDFMimeType.N_QUADS);
       return expect(repository.get(payload)).resolves.toEqual(expected);
@@ -113,14 +117,14 @@ describe('RDFRepositoryClient - reading statements', () => {
     test('should fetch statement in Turtle format and return it converted to quads', () => {
       repository.registerParser(new TurtleParser());
 
-      mockHttpGET(RDFMimeType.TURTLE);
+      mockHttpRequest(RDFMimeType.TURTLE);
 
       const payload = buildPayload(RDFMimeType.TURTLE);
       return expect(repository.get(payload)).resolves.toEqual(expected);
     });
 
     test('should fetch statement in jsonld format and return it converted to quads', () => {
-      repository.httpClients[0].get.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: FileUtils.getReadStream(jsonldDataFile)
       });
 
@@ -143,7 +147,7 @@ describe('RDFRepositoryClient - reading statements', () => {
     });
 
     test('should fetch statement in rdfxml format and return it converted to quads', () => {
-      repository.httpClients[0].get.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: FileUtils.getReadStream(rdfxmlDataFile)
       });
 
@@ -168,15 +172,13 @@ describe('RDFRepositoryClient - reading statements', () => {
 
   describe('statements#get returning plain string', () => {
     test('should reject with error if response fails', () => {
-      repository.httpClients[0].get.mockImplementation(() => Promise.reject({response: 'Server error'}));
+      httpRequest.mockRejectedValue({response: 'Server error'});
 
       return expect(repository.get(new GetStatementsPayload())).rejects.toEqual({response: 'Server error'});
     });
 
     test('should populate http header and parameters according to provided data', () => {
-      repository.httpClients[0].get.mockImplementation(() => {
-        return Promise.resolve({data: ''});
-      });
+      httpRequest.mockResolvedValue({data: ''});
 
       const payload = new GetStatementsPayload()
         .setResponseType(RDFMimeType.RDF_JSON)
@@ -206,24 +208,24 @@ describe('RDFRepositoryClient - reading statements', () => {
     });
 
     function verifyGetRequest() {
-      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-        'Accept': RDFMimeType.RDF_JSON
-      }).setParams({
-        infer: true,
-        subj: '<http://eunis.eea.europa.eu/countries/AZ>',
-        pred: '<http://eunis.eea.europa.eu/rdf/schema.rdf#population>',
-        obj: '"7931000"^^http://www.w3.org/2001/XMLSchema#integer',
-        context: '<http://example.org/graph3>'
-      });
+      const expectedRequestConfig = HttpRequestBuilder.httpGet('/statements')
+        .setHeaders({
+          'Accept': RDFMimeType.RDF_JSON
+        }).setParams({
+          infer: true,
+          subj: '<http://eunis.eea.europa.eu/countries/AZ>',
+          pred: '<http://eunis.eea.europa.eu/rdf/schema.rdf#population>',
+          obj: '"7931000"^^http://www.w3.org/2001/XMLSchema#integer',
+          context: '<http://example.org/graph3>'
+        });
 
-      const httpGet = repository.httpClients[0].get;
-      expect(httpGet).toHaveBeenCalledWith('/statements', expectedRequestConfig);
+      expect(httpRequest).toHaveBeenCalledWith(expectedRequestConfig);
     }
 
     test('should fetch and return single statement as plain string', () => {
-      repository.httpClients[0].get.mockImplementation(() => Promise.resolve({
+      httpRequest.mockResolvedValue({
         data: data.repositories.repo1.statements.GET['single_application/rdf+xml']
-      }));
+      });
 
       const payload = new GetStatementsPayload()
         .setSubject('<http://eunis.eea.europa.eu/countries/AZ>')
@@ -242,9 +244,9 @@ describe('RDFRepositoryClient - reading statements', () => {
     });
 
     test('should fetch and return all statement as plain string', () => {
-      repository.httpClients[0].get.mockImplementation(() => Promise.resolve({
+      httpRequest.mockResolvedValue({
         data: data.repositories.repo1.statements.GET['all_application/rdf+xml']
-      }));
+      });
       const expected = '<?xml version="1.0" encoding="UTF-8"?><rdf:RDF xmlns="http://eunis.eea.europa.eu/rdf/schema.rdf#"><rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"><rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/></rdf:Description><rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subPropertyOf"><rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/><rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/></rdf:Description><rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#subClassOf"><rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/><rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/></rdf:Description><rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#domain"><rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/></rdf:Description></rdf:RDF>';
 
       const payload = new GetStatementsPayload();
@@ -266,7 +268,7 @@ describe('RDFRepositoryClient - reading statements', () => {
         .setObject('"7931000"^^http://www.w3.org/2001/XMLSchema#integer')
         .setContext('<http://example.org/graph3>');
 
-      repository.httpClients[0].get.mockResolvedValue({
+      httpRequest.mockResolvedValue({
         data: stream
       });
 
@@ -279,7 +281,6 @@ describe('RDFRepositoryClient - reading statements', () => {
     });
 
     test('should make a GET request with proper arguments', () => {
-      const getMock = repository.httpClients[0].get;
       const payload = new GetStatementsPayload()
         .setResponseType(RDFMimeType.TURTLE)
         .setSubject('<http://eunis.eea.europa.eu/countries/AZ>')
@@ -289,12 +290,11 @@ describe('RDFRepositoryClient - reading statements', () => {
         .setInference(true);
 
       return repository.download(payload).then(() => {
-        verifyDownloadRequest(getMock);
+        verifyDownloadRequest();
       });
     });
 
     test('should convert the download request to N-Triple resources if not already encoded', () => {
-      const getMock = repository.httpClients[0].get;
       const payload = new GetStatementsPayload()
         .setResponseType(RDFMimeType.TURTLE)
         .setSubject('http://eunis.eea.europa.eu/countries/AZ')
@@ -304,22 +304,24 @@ describe('RDFRepositoryClient - reading statements', () => {
         .setInference(true);
 
       return repository.download(payload).then(() => {
-        verifyDownloadRequest(getMock);
+        verifyDownloadRequest();
       });
     });
 
-    function verifyDownloadRequest(getMock) {
-      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-        'Accept': 'text/turtle'
-      }).setParams({
-        subj: '<http://eunis.eea.europa.eu/countries/AZ>',
-        pred: '<http://eunis.eea.europa.eu/rdf/schema.rdf#population>',
-        obj: '"7931000"^^http://www.w3.org/2001/XMLSchema#integer',
-        context: '<http://example.org/graph3>',
-        infer: true
-      }).setResponseType('stream');
-      expect(getMock).toHaveBeenCalledTimes(1);
-      expect(getMock).toHaveBeenCalledWith('/statements', expectedRequestConfig);
+    function verifyDownloadRequest() {
+      const expectedRequestConfig = HttpRequestBuilder.httpGet('/statements')
+        .setHeaders({
+          'Accept': 'text/turtle'
+        }).setParams({
+          subj: '<http://eunis.eea.europa.eu/countries/AZ>',
+          pred: '<http://eunis.eea.europa.eu/rdf/schema.rdf#population>',
+          obj: '"7931000"^^http://www.w3.org/2001/XMLSchema#integer',
+          context: '<http://example.org/graph3>',
+          infer: true
+        })
+        .setResponseType('stream');
+      expect(httpRequest).toHaveBeenCalledTimes(1);
+      expect(httpRequest).toHaveBeenCalledWith(expectedRequestConfig);
     }
 
     function streamSource() {

--- a/test/repository/rdf-repository-client-streaming-data.spec.js
+++ b/test/repository/rdf-repository-client-streaming-data.spec.js
@@ -2,7 +2,7 @@ const HttpClient = require('http/http-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const RdfRepositoryClient = require('repository/rdf-repository-client');
 const RDFMimeType = require('http/rdf-mime-type');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 const {ObjectReadableMock} = require('stream-mock');
 
 const httpClientStub = require('../http/http-client.stub');
@@ -68,7 +68,7 @@ describe('RdfRepositoryClient - streaming data', () => {
     });
 
     function verifyUploadRequest(postMock) {
-      const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
         'Content-Type': 'text/turtle'
       }).setParams({
         context,
@@ -117,7 +117,7 @@ describe('RdfRepositoryClient - streaming data', () => {
     });
 
     function verifyOverwriteRequest(putMock) {
-      const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
         'Content-Type': 'text/turtle'
       }).setParams({
         context,

--- a/test/repository/rdf-repository-client-streaming-data.spec.js
+++ b/test/repository/rdf-repository-client-streaming-data.spec.js
@@ -12,14 +12,15 @@ jest.mock('http/http-client');
 describe('RdfRepositoryClient - streaming data', () => {
   let repoClientConfig;
   let rdfRepositoryClient;
-
-  const endpoints = ['http://host/repositories/repo1'];
-  const headers = {};
-  const contentType = '';
-  const readTimeout = 1000;
-  const writeTimeout = 1000;
+  let httpRequest;
 
   beforeEach(() => {
+    const endpoints = ['http://host/repositories/repo1'];
+    const headers = {};
+    const contentType = '';
+    const readTimeout = 1000;
+    const writeTimeout = 1000;
+
     HttpClient.mockImplementation(() => httpClientStub());
 
     repoClientConfig = new RepositoryClientConfig()
@@ -29,6 +30,7 @@ describe('RdfRepositoryClient - streaming data', () => {
       .setReadTimeout(readTimeout)
       .setWriteTimeout(writeTimeout);
     rdfRepositoryClient = new RdfRepositoryClient(repoClientConfig);
+    httpRequest = rdfRepositoryClient.httpClients[0].request;
   });
 
   describe('upload', () => {
@@ -51,32 +53,30 @@ describe('RdfRepositoryClient - streaming data', () => {
     });
 
     test('should make a POST request with proper parameters and headers', () => {
-      const postMock = rdfRepositoryClient.httpClients[0].post;
-
       return rdfRepositoryClient.upload({}, contentType, context, baseURI).then(() => {
-        verifyUploadRequest(postMock);
+        verifyUploadRequest();
       });
     });
 
     test('should make a POST request with properly encoded context parameter', () => {
-      const postMock = rdfRepositoryClient.httpClients[0].post;
-
       // Not encoded as N-Triple
       return rdfRepositoryClient.upload({}, contentType, 'urn:x-local:graph1', baseURI).then(() => {
-        verifyUploadRequest(postMock);
+        verifyUploadRequest();
       });
     });
 
-    function verifyUploadRequest(postMock) {
-      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-        'Content-Type': 'text/turtle'
-      }).setParams({
-        context,
-        baseURI
-      }).setResponseType('stream');
+    function verifyUploadRequest() {
+      const expectedRequestConfig = HttpRequestBuilder.httpPost('/statements')
+        .setData({})
+        .setHeaders({
+          'Content-Type': 'text/turtle'
+        }).setParams({
+          context,
+          baseURI
+        }).setResponseType('stream');
 
-      expect(postMock).toHaveBeenCalledTimes(1);
-      expect(postMock).toHaveBeenCalledWith('/statements', {}, expectedRequestConfig);
+      expect(httpRequest).toHaveBeenCalledTimes(1);
+      expect(httpRequest).toHaveBeenCalledWith(expectedRequestConfig);
     }
   });
 
@@ -100,32 +100,30 @@ describe('RdfRepositoryClient - streaming data', () => {
     });
 
     test('should make a PUT request with proper parameters and headers', () => {
-      const putMock = rdfRepositoryClient.httpClients[0].put;
-
       return rdfRepositoryClient.overwrite({}, contentType, context, baseURI).then(() => {
-        verifyOverwriteRequest(putMock);
+        verifyOverwriteRequest();
       });
     });
 
     test('should make a PUT request with properly encoded context parameter', () => {
-      const putMock = rdfRepositoryClient.httpClients[0].put;
-
       // Not encoded as N-Triple
       return rdfRepositoryClient.overwrite({}, contentType, 'urn:x-local:graph1', baseURI).then(() => {
-        verifyOverwriteRequest(putMock);
+        verifyOverwriteRequest();
       });
     });
 
-    function verifyOverwriteRequest(putMock) {
-      const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-        'Content-Type': 'text/turtle'
-      }).setParams({
-        context,
-        baseURI
-      }).setResponseType('stream');
+    function verifyOverwriteRequest() {
+      const expectedRequestConfig = HttpRequestBuilder.httpPut('/statements')
+        .setData({})
+        .setHeaders({
+          'Content-Type': 'text/turtle'
+        }).setParams({
+          context,
+          baseURI
+        }).setResponseType('stream');
 
-      expect(putMock).toHaveBeenCalledTimes(1);
-      expect(putMock).toHaveBeenCalledWith('/statements', {}, expectedRequestConfig);
+      expect(httpRequest).toHaveBeenCalledTimes(1);
+      expect(httpRequest).toHaveBeenCalledWith(expectedRequestConfig);
     }
   });
 

--- a/test/repository/rdf-repository-client-transactions.spec.js
+++ b/test/repository/rdf-repository-client-transactions.spec.js
@@ -11,7 +11,7 @@ const GetQueryPayload = require('query/get-query-payload');
 const QueryType = require('query/query-type');
 const UpdateQueryPayload = require('query/update-query-payload');
 const QueryContentType = require('http/query-content-type');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
 const {namedNode, literal, quad} = require('n3').DataFactory;
 
@@ -60,10 +60,10 @@ describe('RDFRepositoryClient - transactions', () => {
   });
 
   /**
-   * Utility for creating HttpRequestConfigBuilder from given config.
+   * Utility for creating HttpRequestBuilder from given config.
    */
   function getRequestConfig(config) {
-    const requestConfig = new HttpRequestConfigBuilder();
+    const requestConfig = new HttpRequestBuilder();
     requestConfig.config = config;
     return requestConfig;
   }
@@ -96,7 +96,7 @@ describe('RDFRepositoryClient - transactions', () => {
         expect(transactionalClient.isActive()).toEqual(true);
 
         expect(post).toHaveBeenCalledTimes(1);
-        expect(post).toHaveBeenCalledWith('/transactions', new HttpRequestConfigBuilder());
+        expect(post).toHaveBeenCalledWith('/transactions', new HttpRequestBuilder());
       });
     });
 

--- a/test/repository/rdf-repository-client-transactions.spec.js
+++ b/test/repository/rdf-repository-client-transactions.spec.js
@@ -12,11 +12,11 @@ const QueryType = require('query/query-type');
 const UpdateQueryPayload = require('query/update-query-payload');
 const QueryContentType = require('http/query-content-type');
 const HttpRequestBuilder = require('http/http-request-builder');
+const Stream = require('stream');
 
 const {namedNode, literal, quad} = require('n3').DataFactory;
 
 const httpClientStub = require('../http/http-client.stub');
-const {when} = require('jest-when');
 const testUtils = require('../utils');
 const path = require('path');
 
@@ -26,6 +26,7 @@ describe('RDFRepositoryClient - transactions', () => {
 
   let repoClientConfig;
   let rdfRepositoryClient;
+  let httpRequest;
 
   const defaultHeaders = {
     'Accept': 'application/json'
@@ -50,31 +51,17 @@ describe('RDFRepositoryClient - transactions', () => {
     HttpClient.mockImplementation((baseUrl) => httpClientStub(baseUrl));
 
     rdfRepositoryClient = new RDFRepositoryClient(repoClientConfig);
+    httpRequest = rdfRepositoryClient.httpClients[0].request;
 
     const response = {
       headers: {
         'location': transactionUrl
       }
     };
-    when(rdfRepositoryClient.httpClients[0].post).calledWith('/transactions').mockResolvedValue(response);
+    httpRequest.mockResolvedValue(response);
   });
 
-  /**
-   * Utility for creating HttpRequestBuilder from given config.
-   */
-  function getRequestConfig(config) {
-    const requestConfig = new HttpRequestBuilder();
-    requestConfig.config = config;
-    return requestConfig;
-  }
-
   describe('beginTransaction()', () => {
-
-    let post;
-    beforeEach(() => {
-      post = rdfRepositoryClient.httpClients[0].post;
-    });
-
     test('should start a transaction and produce transactional client', () => {
       return rdfRepositoryClient.beginTransaction().then(transactionalClient => {
         expect(transactionalClient).toBeInstanceOf(TransactionalRepositoryClient);
@@ -95,8 +82,8 @@ describe('RDFRepositoryClient - transactions', () => {
 
         expect(transactionalClient.isActive()).toEqual(true);
 
-        expect(post).toHaveBeenCalledTimes(1);
-        expect(post).toHaveBeenCalledWith('/transactions', new HttpRequestBuilder());
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpPost('/transactions'));
       });
     });
 
@@ -104,12 +91,12 @@ describe('RDFRepositoryClient - transactions', () => {
       return rdfRepositoryClient.beginTransaction(TransactionIsolationLevel.READ_UNCOMMITTED).then(transactionalClient => {
         expect(transactionalClient).toBeInstanceOf(TransactionalRepositoryClient);
 
-        expect(post).toHaveBeenCalledTimes(1);
-        expect(post).toHaveBeenCalledWith('/transactions', getRequestConfig({
-          params: {
+        const expectedRequest = HttpRequestBuilder.httpPost('/transactions')
+          .setParams({
             'isolation-level': TransactionIsolationLevel.READ_UNCOMMITTED
-          }
-        }));
+          });
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(expectedRequest);
       });
     });
 
@@ -119,12 +106,12 @@ describe('RDFRepositoryClient - transactions', () => {
         transactionalClient = client;
         return transactionalClient.commit();
       }).then(() => {
-        expect(transactionalClient.httpClients[0].put).toHaveBeenCalledTimes(1);
-        expect(transactionalClient.httpClients[0].put).toHaveBeenCalledWith('', null, getRequestConfig({
-          params: {
-            action: 'COMMIT'
-          }
-        }));
+        const expectedRequest = HttpRequestBuilder.httpPut('').setParams({
+          action: 'COMMIT'
+        });
+        const transactionalHttpRequest = transactionalClient.httpClients[0].request;
+        expect(transactionalHttpRequest).toHaveBeenCalledTimes(1);
+        expect(transactionalHttpRequest).toHaveBeenCalledWith(expectedRequest);
         expect(transactionalClient.isActive()).toEqual(false);
       });
     });
@@ -135,15 +122,16 @@ describe('RDFRepositoryClient - transactions', () => {
         transactionalClient = client;
         return transactionalClient.rollback();
       }).then(() => {
-        expect(transactionalClient.httpClients[0].deleteResource).toHaveBeenCalledTimes(1);
-        expect(transactionalClient.httpClients[0].deleteResource).toHaveBeenCalledWith('');
+        const transactionalHttpRequest = transactionalClient.httpClients[0].request;
+        expect(transactionalHttpRequest).toHaveBeenCalledTimes(1);
+        expect(transactionalHttpRequest).toHaveBeenCalledWith(HttpRequestBuilder.httpDelete(''));
         expect(transactionalClient.isActive()).toEqual(false);
       });
     });
 
     test('should reject if it cannot start a transaction', () => {
       const err = new Error('Cannot begin transaction');
-      when(post).calledWith('/transactions').mockRejectedValue(err);
+      httpRequest.mockRejectedValue(err);
       return expect(rdfRepositoryClient.beginTransaction()).rejects.toEqual(err);
     });
 
@@ -164,7 +152,7 @@ describe('RDFRepositoryClient - transactions', () => {
       let transactionalClient;
       return rdfRepositoryClient.beginTransaction().then(client => {
         transactionalClient = client;
-        transactionalClient.httpClients[0].put.mockRejectedValue(err);
+        transactionalClient.httpClients[0].request.mockRejectedValue(err);
         return expect(transactionalClient.commit()).rejects.toEqual(err);
       });
     });
@@ -174,7 +162,7 @@ describe('RDFRepositoryClient - transactions', () => {
       let transactionalClient;
       return rdfRepositoryClient.beginTransaction().then(client => {
         transactionalClient = client;
-        transactionalClient.httpClients[0].put.mockRejectedValue(err);
+        transactionalClient.httpClients[0].request.mockRejectedValue(err);
         return transactionalClient.commit();
       }).catch(() => {
         expect(() => transactionalClient.getSize()).toThrow();
@@ -200,7 +188,7 @@ describe('RDFRepositoryClient - transactions', () => {
       let transactionalClient;
       return rdfRepositoryClient.beginTransaction().then(client => {
         transactionalClient = client;
-        transactionalClient.httpClients[0].deleteResource.mockRejectedValue(err);
+        transactionalClient.httpClients[0].request.mockRejectedValue(err);
         return expect(transactionalClient.rollback()).rejects.toEqual(err);
       });
     });
@@ -210,7 +198,7 @@ describe('RDFRepositoryClient - transactions', () => {
       let transactionalClient;
       return rdfRepositoryClient.beginTransaction().then(client => {
         transactionalClient = client;
-        transactionalClient.httpClients[0].deleteResource.mockRejectedValue(err);
+        transactionalClient.httpClients[0].request.mockRejectedValue(err);
         return transactionalClient.rollback();
       }).catch(() => {
         expect(() => transactionalClient.getSize()).toThrow();
@@ -222,7 +210,7 @@ describe('RDFRepositoryClient - transactions', () => {
     test('should reject if it cannot obtain transaction ID', () => {
       // Reset headers
       const response = {headers: {}};
-      when(rdfRepositoryClient.httpClients[0].post).calledWith('/transactions').mockResolvedValue(response);
+      httpRequest.mockResolvedValue(response);
       return expect(rdfRepositoryClient.beginTransaction()).rejects.toEqual(Error('Couldn\'t obtain transaction ID'));
     });
   });
@@ -230,48 +218,48 @@ describe('RDFRepositoryClient - transactions', () => {
   describe('Having started transaction', () => {
 
     let transaction;
-    let httpPut;
+    let transactionHttpRequest;
 
     const data = '<http://domain/resource/resource-1> <http://domain/property/relation-1> "Title"@en.';
 
     beforeEach(() => {
       return rdfRepositoryClient.beginTransaction().then(tr => {
         transaction = tr;
-        httpPut = transaction.httpClients[0].put;
+        transactionHttpRequest = transaction.httpClients[0].request;
       });
     });
 
     describe('getSize()', () => {
       test('should retrieve the repository size', () => {
-        httpPut.mockResolvedValue({data: 123});
+        transactionHttpRequest.mockResolvedValue({data: 123});
         return transaction.getSize().then(size => {
           expect(size).toEqual(123);
-          expect(httpPut).toHaveBeenCalledTimes(1);
-          expect(httpPut).toHaveBeenCalledWith('', null, getRequestConfig({
-            params: {
-              action: 'SIZE',
-              context: undefined
-            }
-          }));
+
+          const expectedRequest = HttpRequestBuilder.httpPut('').setParams({
+            action: 'SIZE',
+            context: undefined
+          });
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
         });
       });
 
       test('should retrieve the repository size in specific context', () => {
-        httpPut.mockResolvedValue({data: 123});
+        transactionHttpRequest.mockResolvedValue({data: 123});
         return transaction.getSize('<http://domain/context>').then(size => {
           expect(size).toEqual(123);
-          expect(httpPut).toHaveBeenCalledTimes(1);
-          expect(httpPut).toHaveBeenCalledWith('', null, getRequestConfig({
-            params: {
-              action: 'SIZE',
-              context: '<http://domain/context>'
-            }
-          }));
+
+          const expectedRequest = HttpRequestBuilder.httpPut('').setParams({
+            action: 'SIZE',
+            context: '<http://domain/context>'
+          });
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
         });
       });
 
       test('should reject if the transaction cannot retrieve the repository size', () => {
-        httpPut.mockRejectedValue('Error during size retrieve');
+        transactionHttpRequest.mockRejectedValue('Error during size retrieve');
         return expect(transaction.getSize()).rejects.toEqual('Error during size retrieve');
       });
     });
@@ -279,7 +267,7 @@ describe('RDFRepositoryClient - transactions', () => {
     describe('get()', () => {
       test('should retrieve statements', () => {
         const data = testUtils.loadFile(testFilePath).trim();
-        httpPut.mockResolvedValue({data});
+        transactionHttpRequest.mockResolvedValue({data});
         return transaction.get(getStatementPayload()).then((result) => {
           expect(result).toEqual(data);
         });
@@ -287,23 +275,25 @@ describe('RDFRepositoryClient - transactions', () => {
 
       test('should properly request to retrieve statements', () => {
         return transaction.get(getStatementPayload()).then(() => {
-          expect(httpPut).toHaveBeenCalledTimes(1);
-          expect(httpPut).toHaveBeenCalledWith('', null, getRequestConfig({
-            headers: {'Accept': RDFMimeType.RDF_JSON},
-            params: {
+          const expectedRequest = HttpRequestBuilder.httpPut('')
+            .setHeaders({
+              'Accept': RDFMimeType.RDF_JSON
+            })
+            .setParams({
               action: 'GET',
               context: '<http://example.org/graph3>',
               infer: true,
               obj: '"7931000"^^http://www.w3.org/2001/XMLSchema#integer',
               pred: '<http://eunis.eea.europa.eu/rdf/schema.rdf#population>',
               subj: '<http://eunis.eea.europa.eu/countries/AZ>'
-            }
-          }));
+            });
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
         });
       });
 
       test('should reject if the transaction cannot retrieve statements', () => {
-        httpPut.mockRejectedValue('Error during retrieve');
+        transactionHttpRequest.mockRejectedValue('Error during retrieve');
         return expect(transaction.get(getStatementPayload())).rejects.toEqual('Error during retrieve');
       });
     });
@@ -317,32 +307,33 @@ describe('RDFRepositoryClient - transactions', () => {
         .setTimeout(5);
 
       test('should query data', () => {
-        httpPut.mockResolvedValue({data: true});
+        transactionHttpRequest.mockResolvedValue({data: true});
         return transaction.query(payload).then((response) => {
           expect(response).toEqual(true);
         });
       });
 
       test('should properly perform query request', () => {
-        httpPut.mockResolvedValue({data: true});
+        transactionHttpRequest.mockResolvedValue({data: true});
         return transaction.query(payload).then(() => {
-          expect(httpPut).toHaveBeenCalledTimes(1);
-          expect(httpPut).toHaveBeenCalledWith('', 'ask {?s ?p ?o}', getRequestConfig({
-            params: {
-              action: 'QUERY'
-            },
-            headers: {
+          const expectedRequest = HttpRequestBuilder.httpPut('')
+            .setData('ask {?s ?p ?o}')
+            .setHeaders({
               'Accept': 'text/boolean',
               'Content-Type': QueryContentType.SPARQL_QUERY
-            },
-            responseType: 'stream'
-          }));
+            })
+            .setParams({
+              action: 'QUERY'
+            })
+            .setResponseType('stream');
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
         });
       });
 
       test('should reject if the transaction cannot perform a query request', () => {
         const err = new Error('Cannot query');
-        httpPut.mockRejectedValue(err);
+        transactionHttpRequest.mockRejectedValue(err);
         return expect(transaction.query(payload)).rejects.toEqual(err);
       });
     });
@@ -354,21 +345,22 @@ describe('RDFRepositoryClient - transactions', () => {
 
       test('should perform update with proper request', () => {
         return transaction.update(updatePayload).then(() => {
-          expect(httpPut).toHaveBeenCalledTimes(1);
-          expect(httpPut).toHaveBeenCalledWith('', 'INSERT {?s ?p ?o} WHERE {?s ?p ?o}', getRequestConfig({
-            params: {
-              action: 'UPDATE'
-            },
-            headers: {
+          const expectedRequest = HttpRequestBuilder.httpPut('')
+            .setData('INSERT {?s ?p ?o} WHERE {?s ?p ?o}')
+            .setHeaders({
               'Content-Type': QueryContentType.SPARQL_UPDATE
-            }
-          }));
+            })
+            .setParams({
+              action: 'UPDATE'
+            });
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
         });
       });
 
       test('should reject if the transaction cannot perform an update request', () => {
         const err = new Error('Cannot update');
-        httpPut.mockRejectedValue(err);
+        transactionHttpRequest.mockRejectedValue(err);
         return expect(transaction.update(updatePayload)).rejects.toEqual(err);
       });
 
@@ -427,7 +419,7 @@ describe('RDFRepositoryClient - transactions', () => {
       });
 
       test('should reject if the transaction cannot insert statements', () => {
-        httpPut.mockRejectedValue('Error during add');
+        transactionHttpRequest.mockRejectedValue('Error during add');
         return expect(transaction.add(payload)).rejects.toEqual('Error during add');
       });
 
@@ -465,7 +457,7 @@ describe('RDFRepositoryClient - transactions', () => {
           namedNode('http://domain/property/relation-1'),
           literal('Title', 'en'));
 
-        httpPut.mockRejectedValue('Error during quads add');
+        transactionHttpRequest.mockRejectedValue('Error during quads add');
         return expect(transaction.addQuads([q])).rejects.toEqual('Error during quads add');
       });
 
@@ -489,11 +481,11 @@ describe('RDFRepositoryClient - transactions', () => {
         expect(() => transaction.sendData()).toThrow();
         expect(() => transaction.sendData('')).toThrow();
         expect(() => transaction.sendData('  ')).toThrow();
-        expect(httpPut).toHaveBeenCalledTimes(0);
+        expect(transactionHttpRequest).toHaveBeenCalledTimes(0);
       });
 
       test('should reject if the transaction cannot add data', () => {
-        httpPut.mockRejectedValue('Error during add');
+        transactionHttpRequest.mockRejectedValue('Error during add');
         return expect(transaction.sendData(data)).rejects.toEqual('Error during add');
       });
 
@@ -503,35 +495,37 @@ describe('RDFRepositoryClient - transactions', () => {
     });
 
     function expectInsertedData(expectedData, expectedContext, expectedBaseURI) {
-      expect(httpPut).toHaveBeenCalledTimes(1);
-      expect(httpPut).toHaveBeenCalledWith('', expectedData, getRequestConfig({
-        headers: {
+      const expectedRequest = HttpRequestBuilder.httpPut('')
+        .setData(expectedData)
+        .setHeaders({
           'Content-Type': RDFMimeType.TRIG
-        },
-        params: {
+        })
+        .setParams({
           action: 'ADD',
           context: expectedContext,
           baseURI: expectedBaseURI
-        }
-      }));
+        });
+      expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+      expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
     }
 
     function expectNoInsertedData() {
-      expect(httpPut).toHaveBeenCalledTimes(0);
+      expect(transactionHttpRequest).toHaveBeenCalledTimes(0);
     }
 
     describe('deleteData()', () => {
       test('should delete data', () => {
         return transaction.deleteData(data).then(() => {
-          expect(httpPut).toHaveBeenCalledTimes(1);
-          expect(httpPut).toHaveBeenCalledWith('', data, getRequestConfig({
-            headers: {
+          const expectedRequest = HttpRequestBuilder.httpPut('')
+            .setData(data)
+            .setHeaders({
               'Content-Type': RDFMimeType.TRIG
-            },
-            params: {
+            })
+            .setParams({
               action: 'DELETE'
-            }
-          }));
+            });
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
         });
       });
 
@@ -539,11 +533,11 @@ describe('RDFRepositoryClient - transactions', () => {
         expect(() => transaction.deleteData()).toThrow();
         expect(() => transaction.deleteData('')).toThrow();
         expect(() => transaction.deleteData('  ')).toThrow();
-        expect(httpPut).toHaveBeenCalledTimes(0);
+        expect(transactionHttpRequest).toHaveBeenCalledTimes(0);
       });
 
       test('should reject if the transaction cannot delete data', () => {
-        httpPut.mockRejectedValue('Error during delete');
+        transactionHttpRequest.mockRejectedValue('Error during delete');
         return expect(transaction.deleteData(data)).rejects.toEqual('Error during delete');
       });
 
@@ -554,7 +548,7 @@ describe('RDFRepositoryClient - transactions', () => {
 
     describe('download()', () => {
       test('should download data', () => {
-        httpPut.mockResolvedValue({
+        transactionHttpRequest.mockResolvedValue({
           data: FileUtils.getReadStream(testFilePath)
         });
         return transaction.download(getStatementPayload()).then((dataStream) => {
@@ -566,29 +560,31 @@ describe('RDFRepositoryClient - transactions', () => {
       });
 
       test('should properly request to download data', () => {
-        httpPut.mockResolvedValue({
+        transactionHttpRequest.mockResolvedValue({
           data: FileUtils.getReadStream(testFilePath)
         });
         return transaction.download(getStatementPayload()).then(() => {
-          expect(httpPut).toHaveBeenCalledTimes(1);
-          expect(httpPut).toHaveBeenCalledWith('', null, getRequestConfig({
-            headers: {'Accept': RDFMimeType.RDF_JSON},
-            params: {
+          const expectedRequest = HttpRequestBuilder.httpPut('')
+            .setHeaders({
+              'Accept': RDFMimeType.RDF_JSON
+            })
+            .setParams({
               action: 'GET',
               context: '<http://example.org/graph3>',
               infer: true,
               obj: '"7931000"^^http://www.w3.org/2001/XMLSchema#integer',
               pred: '<http://eunis.eea.europa.eu/rdf/schema.rdf#population>',
               subj: '<http://eunis.eea.europa.eu/countries/AZ>'
-            },
-            responseType: 'stream'
-          }));
+            })
+            .setResponseType('stream');
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          expect(transactionHttpRequest).toHaveBeenCalledWith(expectedRequest);
         });
       });
 
       test('should reject if the transaction cannot download data', () => {
         const err = new Error('Cannot download data');
-        httpPut.mockRejectedValue(err);
+        transactionHttpRequest.mockRejectedValue(err);
         return expect(transaction.download(getStatementPayload())).rejects.toEqual(err);
       });
     });
@@ -598,28 +594,10 @@ describe('RDFRepositoryClient - transactions', () => {
         const turtleStream = FileUtils.getReadStream(testFilePath);
 
         return transaction.upload(turtleStream, RDFMimeType.TRIG, context, baseURI).then(() => {
-          expect(httpPut).toHaveBeenCalledTimes(1);
-
-          const httpPutCall = httpPut.mock.calls[0];
-
-          const url = httpPutCall[0];
-          expect(url).toEqual('');
-
-          const requestConfig = httpPutCall[2];
-          expect(requestConfig).toEqual(getRequestConfig({
-            headers: {
-              'Content-Type': RDFMimeType.TRIG
-            },
-            params: {
-              action: 'ADD',
-              context,
-              baseURI
-            },
-            responseType: 'stream'
-          }));
-
-          const stream = httpPutCall[1];
-          return testUtils.readStream(stream);
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          const requestBuilder = transactionHttpRequest.mock.calls[0][0];
+          verifyUploadRequestBuilder(requestBuilder);
+          return testUtils.readStream(requestBuilder.getData());
         }).then((streamData) => {
           const turtleData = testUtils.loadFile(testFilePath).trim();
           expect(streamData).toEqual(turtleData);
@@ -628,7 +606,7 @@ describe('RDFRepositoryClient - transactions', () => {
 
       test('should reject if the server cannot consume the upload request', () => {
         const error = new Error('cannot-upload');
-        httpPut.mockRejectedValue(error);
+        transactionHttpRequest.mockRejectedValue(error);
 
         const turtleStream = FileUtils.getReadStream(testFilePath);
         const promise = transaction.upload(turtleStream, RDFMimeType.TRIG, context, null);
@@ -646,28 +624,10 @@ describe('RDFRepositoryClient - transactions', () => {
 
       test('should upload file with data as stream in given context and base URI', () => {
         return transaction.addFile(testFilePath, RDFMimeType.TRIG, context, baseURI).then(() => {
-          expect(httpPut).toHaveBeenCalledTimes(1);
-
-          const httpPutCall = httpPut.mock.calls[0];
-
-          const url = httpPutCall[0];
-          expect(url).toEqual('');
-
-          const requestConfig = httpPutCall[2];
-          expect(requestConfig).toEqual(getRequestConfig({
-            headers: {
-              'Content-Type': RDFMimeType.TRIG
-            },
-            params: {
-              action: 'ADD',
-              context,
-              baseURI
-            },
-            responseType: 'stream'
-          }));
-
-          const stream = httpPutCall[1];
-          return testUtils.readStream(stream)
+          expect(transactionHttpRequest).toHaveBeenCalledTimes(1);
+          const requestBuilder = transactionHttpRequest.mock.calls[0][0];
+          verifyUploadRequestBuilder(requestBuilder);
+          return testUtils.readStream(requestBuilder.getData());
         }).then((streamData) => {
           const turtleData = testUtils.loadFile(testFilePath).trim();
           expect(streamData).toEqual(turtleData);
@@ -676,7 +636,7 @@ describe('RDFRepositoryClient - transactions', () => {
 
       test('should reject if the server cannot consume the file upload request', () => {
         const error = new Error('cannot-upload');
-        httpPut.mockRejectedValue(error);
+        transactionHttpRequest.mockRejectedValue(error);
 
         const promise = transaction.addFile(testFilePath, RDFMimeType.TRIG, context, null);
         return expect(promise).rejects.toEqual(error);
@@ -692,6 +652,22 @@ describe('RDFRepositoryClient - transactions', () => {
         return expect(transaction.addFile(testFilePath, RDFMimeType.TRIG, context, baseURI)).resolves.toEqual();
       });
     });
+
+    function verifyUploadRequestBuilder(requestBuilder) {
+      expect(requestBuilder).toBeInstanceOf(HttpRequestBuilder);
+      expect(requestBuilder.getMethod()).toEqual('put');
+      expect(requestBuilder.getUrl()).toEqual('');
+      expect(requestBuilder.getData()).toBeInstanceOf(Stream);
+      expect(requestBuilder.getHeaders()).toEqual({
+        'Content-Type': RDFMimeType.TRIG
+      });
+      expect(requestBuilder.getParams()).toEqual({
+        action: 'ADD',
+        baseURI,
+        context
+      });
+      expect(requestBuilder.getResponseType()).toEqual('stream');
+    }
 
     function getStatementPayload() {
       return new GetStatementsPayload()

--- a/test/repository/rdf-repository-client-update-query.spec.js
+++ b/test/repository/rdf-repository-client-update-query.spec.js
@@ -3,7 +3,7 @@ const RDFRepositoryClient = require('repository/rdf-repository-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const UpdateQueryPayload = require('query/update-query-payload');
 const QueryContentType = require('http/query-content-type');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
 const httpClientStub = require('../http/http-client.stub');
 
@@ -28,7 +28,7 @@ describe('RDFRepositoryClient - update query', () => {
     const payload = new UpdateQueryPayload()
       .setQuery('INSERT {?s ?p ?o} WHERE {?s ?p ?o}');
 
-    const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+    const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
       'Content-Type': 'application/sparql-update'
     });
 
@@ -47,7 +47,7 @@ describe('RDFRepositoryClient - update query', () => {
       .setTimeout(5);
 
     const expectedData = 'update=INSERT%20%7B%3Fs%20%3Fp%20%3Fo%7D%20WHERE%20%7B%3Fs%20%3Fp%20%3Fo%7D&infer=true&timeout=5';
-    const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+    const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
       'Content-Type': 'application/x-www-form-urlencoded'
     });
 

--- a/test/repository/rdf-repository-client-uploading-files.spec.js
+++ b/test/repository/rdf-repository-client-uploading-files.spec.js
@@ -3,11 +3,11 @@ const RepositoryClientConfig = require('repository/repository-client-config');
 const RdfRepositoryClient = require('repository/rdf-repository-client');
 const RDFMimeType = require('http/rdf-mime-type');
 const HttpRequestBuilder = require('http/http-request-builder');
+const Stream = require('stream');
 
 const httpClientStub = require('../http/http-client.stub');
 const testUtils = require('../utils');
 const path = require('path');
-const {when} = require('jest-when');
 
 jest.mock('http/http-client');
 
@@ -15,19 +15,19 @@ describe('RdfRepositoryClient - uploading files', () => {
 
   let repoClientConfig;
   let rdfRepositoryClient;
-
-  const endpoints = ['http://host/repositories/repo1'];
-  const headers = {};
-  const contentType = '';
-  const readTimeout = 1000;
-  const writeTimeout = 1000;
+  let httpRequest;
 
   const context = '<urn:x-local:graph1>';
   const baseURI = '<urn:x-local:graph1>';
-
   let testFilePath = path.resolve(__dirname, './data/add-statements-complex.txt');
 
   beforeEach(() => {
+    const endpoints = ['http://host/repositories/repo1'];
+    const headers = {};
+    const contentType = '';
+    const readTimeout = 1000;
+
+    const writeTimeout = 1000;
     HttpClient.mockImplementation(() => httpClientStub());
     repoClientConfig = new RepositoryClientConfig()
       .setEndpoints(endpoints)
@@ -36,36 +36,17 @@ describe('RdfRepositoryClient - uploading files', () => {
       .setReadTimeout(readTimeout)
       .setWriteTimeout(writeTimeout);
     rdfRepositoryClient = new RdfRepositoryClient(repoClientConfig);
+    httpRequest = rdfRepositoryClient.httpClients[0].request;
   });
 
   describe('addFile(file)', () => {
 
-    let httpPost;
-    beforeEach(() => {
-      httpPost = rdfRepositoryClient.httpClients[0].post;
-    });
-
     test('should open a readable stream of the file and send it to the server', () => {
       return rdfRepositoryClient.addFile(testFilePath, RDFMimeType.TRIG, context, baseURI).then(() => {
-        expect(httpPost).toHaveBeenCalledTimes(1);
-
-        const httpPostCall = httpPost.mock.calls[0];
-
-        const url = httpPostCall[0];
-        expect(url).toEqual('/statements');
-
-        const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-          'Content-Type': RDFMimeType.TRIG
-        }).setParams({
-          baseURI,
-          context
-        }).setResponseType('stream');
-
-        const requestConfig = httpPostCall[2];
-        expect(requestConfig).toEqual(expectedRequestConfig);
-
-        const fileStream = httpPostCall[1];
-        return testUtils.readStream(fileStream)
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        const requestBuilder = httpRequest.mock.calls[0][0];
+        verifyUploadRequestBuilder(requestBuilder, 'post');
+        return testUtils.readStream(requestBuilder.getData());
       }).then((streamData) => {
         const expectedData = testUtils.loadFile(testFilePath).trim();
         expect(streamData).toEqual(expectedData);
@@ -74,7 +55,7 @@ describe('RdfRepositoryClient - uploading files', () => {
 
     test('should reject if the server cannot consume the request', () => {
       const error = new Error('cannot-upload-file');
-      when(httpPost).calledWith(expect.stringContaining('/statements')).mockRejectedValue(error);
+      httpRequest.mockRejectedValue(error);
 
       const promise = rdfRepositoryClient.addFile(testFilePath, RDFMimeType.TRIG, context, baseURI);
       return expect(promise).rejects.toEqual(error);
@@ -93,32 +74,12 @@ describe('RdfRepositoryClient - uploading files', () => {
 
   describe('putFile(file)', () => {
 
-    let httpPut;
-    beforeEach(() => {
-      httpPut = rdfRepositoryClient.httpClients[0].put;
-    });
-
     test('should open a readable stream of the file and send it to the server to overwrite the data', () => {
       return rdfRepositoryClient.putFile(testFilePath, RDFMimeType.TRIG, context, baseURI).then(() => {
-        expect(httpPut).toHaveBeenCalledTimes(1);
-
-        const httpPutCall = httpPut.mock.calls[0];
-
-        const url = httpPutCall[0];
-        expect(url).toEqual('/statements');
-
-        const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
-          'Content-Type': RDFMimeType.TRIG
-        }).setParams({
-          baseURI,
-          context
-        }).setResponseType('stream');
-
-        const requestConfig = httpPutCall[2];
-        expect(requestConfig).toEqual(expectedRequestConfig);
-
-        const fileStream = httpPutCall[1];
-        return testUtils.readStream(fileStream)
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        const requestBuilder = httpRequest.mock.calls[0][0];
+        verifyUploadRequestBuilder(requestBuilder, 'put');
+        return testUtils.readStream(requestBuilder.getData());
       }).then((streamData) => {
         const expectedData = testUtils.loadFile(testFilePath).trim();
         expect(streamData).toEqual(expectedData);
@@ -127,7 +88,7 @@ describe('RdfRepositoryClient - uploading files', () => {
 
     test('should reject if the server cannot consume the overwrite request', () => {
       const error = new Error('cannot-upload-file');
-      when(httpPut).calledWith(expect.stringContaining('/statements')).mockRejectedValue(error);
+      httpRequest.mockRejectedValue(error);
 
       const promise = rdfRepositoryClient.putFile(testFilePath, RDFMimeType.TRIG, context, baseURI);
       return expect(promise).rejects.toEqual(error);
@@ -143,5 +104,20 @@ describe('RdfRepositoryClient - uploading files', () => {
       return expect(rdfRepositoryClient.putFile(testFilePath, RDFMimeType.TRIG, context, baseURI)).resolves.toEqual();
     });
   });
+
+  function verifyUploadRequestBuilder(requestBuilder, method) {
+    expect(requestBuilder).toBeInstanceOf(HttpRequestBuilder);
+    expect(requestBuilder.getMethod()).toEqual(method);
+    expect(requestBuilder.getUrl()).toEqual('/statements');
+    expect(requestBuilder.getData()).toBeInstanceOf(Stream);
+    expect(requestBuilder.getHeaders()).toEqual({
+      'Content-Type': RDFMimeType.TRIG
+    });
+    expect(requestBuilder.getParams()).toEqual({
+      baseURI,
+      context
+    });
+    expect(requestBuilder.getResponseType()).toEqual('stream');
+  }
 
 });

--- a/test/repository/rdf-repository-client-uploading-files.spec.js
+++ b/test/repository/rdf-repository-client-uploading-files.spec.js
@@ -2,7 +2,7 @@ const HttpClient = require('http/http-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const RdfRepositoryClient = require('repository/rdf-repository-client');
 const RDFMimeType = require('http/rdf-mime-type');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
 const httpClientStub = require('../http/http-client.stub');
 const testUtils = require('../utils');
@@ -54,7 +54,7 @@ describe('RdfRepositoryClient - uploading files', () => {
         const url = httpPostCall[0];
         expect(url).toEqual('/statements');
 
-        const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+        const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
           'Content-Type': RDFMimeType.TRIG
         }).setParams({
           baseURI,
@@ -107,7 +107,7 @@ describe('RdfRepositoryClient - uploading files', () => {
         const url = httpPutCall[0];
         expect(url).toEqual('/statements');
 
-        const expectedRequestConfig = new HttpRequestConfigBuilder().setHeaders({
+        const expectedRequestConfig = new HttpRequestBuilder().setHeaders({
           'Content-Type': RDFMimeType.TRIG
         }).setParams({
           baseURI,

--- a/test/repository/rdf-repository-client.spec.js
+++ b/test/repository/rdf-repository-client.spec.js
@@ -4,7 +4,6 @@ const ServerClientConfig = require('server/server-client-config');
 const HttpClient = require('http/http-client');
 const HttpRequestBuilder = require('http/http-request-builder');
 const httpClientStub = require('../http/http-client.stub');
-const {when} = require('jest-when');
 
 jest.mock('http/http-client');
 
@@ -73,7 +72,7 @@ describe('RDFRepositoryClient', () => {
   describe('getSize()', () => {
 
     let rdfRepositoryClient;
-    let get;
+    let httpRequest;
 
     beforeEach(() => {
       const repoClientConfig = new RepositoryClientConfig()
@@ -83,8 +82,9 @@ describe('RDFRepositoryClient', () => {
         .setReadTimeout(100)
         .setWriteTimeout(200);
       rdfRepositoryClient = new RDFRepositoryClient(repoClientConfig);
-      get = rdfRepositoryClient.httpClients[0].get;
-      when(get).calledWith('/size').mockResolvedValue({data: 123});
+      httpRequest = rdfRepositoryClient.httpClients[0].request;
+
+      httpRequest.mockResolvedValue({data: 123});
     });
 
     test('should retrieve the number of statements in the repository', () => {
@@ -93,22 +93,22 @@ describe('RDFRepositoryClient', () => {
 
     test('should properly request the number of statements in the repository', () => {
       return rdfRepositoryClient.getSize().then(() => {
-        const expected = new HttpRequestBuilder();
-        expect(get).toHaveBeenCalledTimes(1);
-        expect(get).toHaveBeenCalledWith('/size', expected);
+        const expected = HttpRequestBuilder.httpGet('/size');
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(expected);
       });
     });
 
     test('should properly request the number of statements in the repository for the specified contexts', () => {
       return rdfRepositoryClient.getSize(['context-1']).then(() => {
-        const expected = new HttpRequestBuilder().addParam('context', ['<context-1>']);
-        expect(get).toHaveBeenCalledTimes(1);
-        expect(get).toHaveBeenCalledWith('/size', expected);
+        const expected = HttpRequestBuilder.httpGet('/size').addParam('context', ['<context-1>']);
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).toHaveBeenCalledWith(expected);
       });
     });
 
     test('should reject size retrieving when the server request is unsuccessful', () => {
-      when(get).calledWith('/size').mockRejectedValue('get-size-error');
+      httpRequest.mockRejectedValue('get-size-error');
       return expect(rdfRepositoryClient.getSize()).rejects.toEqual('get-size-error');
     });
   });

--- a/test/repository/rdf-repository-client.spec.js
+++ b/test/repository/rdf-repository-client.spec.js
@@ -2,7 +2,7 @@ const RepositoryClientConfig = require('repository/repository-client-config');
 const RDFRepositoryClient = require('repository/rdf-repository-client');
 const ServerClientConfig = require('server/server-client-config');
 const HttpClient = require('http/http-client');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 const httpClientStub = require('../http/http-client.stub');
 const {when} = require('jest-when');
 
@@ -93,7 +93,7 @@ describe('RDFRepositoryClient', () => {
 
     test('should properly request the number of statements in the repository', () => {
       return rdfRepositoryClient.getSize().then(() => {
-        const expected = new HttpRequestConfigBuilder();
+        const expected = new HttpRequestBuilder();
         expect(get).toHaveBeenCalledTimes(1);
         expect(get).toHaveBeenCalledWith('/size', expected);
       });
@@ -101,7 +101,7 @@ describe('RDFRepositoryClient', () => {
 
     test('should properly request the number of statements in the repository for the specified contexts', () => {
       return rdfRepositoryClient.getSize(['context-1']).then(() => {
-        const expected = new HttpRequestConfigBuilder().addParam('context', ['<context-1>']);
+        const expected = new HttpRequestBuilder().addParam('context', ['<context-1>']);
         expect(get).toHaveBeenCalledTimes(1);
         expect(get).toHaveBeenCalledWith('/size', expected);
       });

--- a/test/server/server-client.test.js
+++ b/test/server/server-client.test.js
@@ -2,7 +2,7 @@ const ServerClient = require('server/server-client');
 const ServerClientConfig = require('server/server-client-config');
 const RDFRepositoryClient = require('repository/rdf-repository-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
-const HttpRequestConfigBuilder = require('http/http-request-config-builder');
+const HttpRequestBuilder = require('http/http-request-builder');
 
 import data from './server-client.data';
 
@@ -41,7 +41,7 @@ describe('ServerClient', () => {
     test('should make request with required service url parameter', () => {
       return server.getRepositoryIDs().then(() => {
         expect(server.httpClient.get).toHaveBeenCalledTimes(1);
-        const expectedRequestConfig = new HttpRequestConfigBuilder()
+        const expectedRequestConfig = new HttpRequestBuilder()
           .setHeaders({
             'Accept': 'application/sparql-results+json'
           });


### PR DESCRIPTION
Changes:
- Renamed HttpRequestConfigBuilder to HttpRequestBuilder
- Refactored HttpRequestBuilder to include method, url and body.
- Removed get/post/put/delete methods from the HttpClient in result. Updated affected classes & tests.
- Removed jest-when dev dependency as it is no longer used. The URL matching is done by comparing HttpRequestBuilders.
- Fixed a bug where the isolation level was no provided as param when starting a transaction.

This is a preparation to extract RDF & transactional clients code to services to reduce code duplication/complexity.