### PR TITLE
Add graphs parameters to UpdateQueryPayload

### DIFF
--- a/src/query/update-query-payload.js
+++ b/src/query/update-query-payload.js
@@ -50,6 +50,73 @@ class UpdateQueryPayload extends QueryPayload {
   }
 
   /**
+   * One or more named graph URIs to be used as default graph(s) for retrieving.
+   * @param {(string|string[])} [defaultGraphs]
+   * @return {UpdateQueryPayload}
+   */
+  setDefaultGraphs(defaultGraphs) {
+    this.payload['using-graph-uri'] = defaultGraphs;
+    return this;
+  }
+
+  /**
+   * @return {(string|string[])} Default graphs for the query for retrieving.
+   */
+  getDefaultGraphs() {
+    return this.payload['using-graph-uri'];
+  }
+
+  /**
+   * One or more named graph URIs to be used as named graph(s) for retrieving.
+   * @param {(string|string[])} [namedGraphs]
+   * @return {UpdateQueryPayload}
+   */
+  setNamedGraphs(namedGraphs) {
+    this.payload['using-named-graph-uri'] = namedGraphs;
+    return this;
+  }
+
+  /**
+   * @return {(string|string[])} Named graphs set for the query for retrieving.
+   */
+  getNamedGraphs() {
+    return this.payload['using-named-graph-uri'];
+  }
+
+  /**
+   * One or more default graphs for removing statements.
+   * @param {(string|string[])} [removeGraphs]
+   * @return {UpdateQueryPayload}
+   */
+  setRemoveGraphs(removeGraphs) {
+    this.payload['remove-graph-uri'] = removeGraphs;
+    return this;
+  }
+
+  /**
+   * @return {(string|string[])} Default graphs set for the query for removing.
+   */
+  getRemoveGraphs() {
+    return this.payload['remove-graph-uri'];
+  }
+
+  /**
+   * One or more default graphs for inserting statements.
+   * @param {(string|string[])} [insertGraphs]
+   * @return {UpdateQueryPayload}
+   */
+  setInsertGraphs(insertGraphs) {
+    this.payload['insert-graph-uri'] = insertGraphs;
+    return this;
+  }
+
+  /**
+   * @return {(string|string[])} Default graphs set for the query for inserting.
+   */
+  getInsertGraphs() {
+    return this.payload['insert-graph-uri'];
+  }
+  /**
    * @inheritDoc
    */
   validateParams() {

--- a/test/query/update-query-payload.spec.js
+++ b/test/query/update-query-payload.spec.js
@@ -33,4 +33,25 @@ describe('UpdateQueryPayload', () => {
       expect(new UpdateQueryPayload().getSupportedContentTypes()).toEqual(['application/x-www-form-urlencoded', 'application/sparql-update']);
     });
   });
+
+  test('should populate graphs parameters in the update payload', () => {
+    let payload = new UpdateQueryPayload()
+      .setDefaultGraphs('<http://example.org/graph1>')
+      .setNamedGraphs('<http://example.org/graph2>')
+      .setRemoveGraphs('<http://example.org/graph3>')
+      .setInsertGraphs('<http://example.org/graph4>');
+    expect(payload.getDefaultGraphs()).toEqual('<http://example.org/graph1>');
+    expect(payload.getNamedGraphs()).toEqual('<http://example.org/graph2>');
+    expect(payload.getRemoveGraphs()).toEqual('<http://example.org/graph3>');
+    expect(payload.getInsertGraphs()).toEqual('<http://example.org/graph4>');
+    expect(payload).toEqual({
+      contentType: QueryContentType.SPARQL_UPDATE,
+      payload: {
+        'using-graph-uri': '<http://example.org/graph1>',
+        'using-named-graph-uri': '<http://example.org/graph2>',
+        'remove-graph-uri': '<http://example.org/graph3>',
+        'insert-graph-uri': '<http://example.org/graph4>' 
+      }
+    });
+  });
 });

--- a/test/repository/rdf-repository-client-update-query.spec.js
+++ b/test/repository/rdf-repository-client-update-query.spec.js
@@ -45,9 +45,13 @@ describe('RDFRepositoryClient - update query', () => {
       .setQuery('INSERT {?s ?p ?o} WHERE {?s ?p ?o}')
       .setContentType(QueryContentType.X_WWW_FORM_URLENCODED)
       .setInference(true)
+      .setDefaultGraphs('<http://example.org/graph1>')
+      .setNamedGraphs('<http://example.org/graph2>')
+      .setRemoveGraphs('<http://example.org/graph3>')
+      .setInsertGraphs('<http://example.org/graph4>')
       .setTimeout(5);
 
-    const expectedData = 'update=INSERT%20%7B%3Fs%20%3Fp%20%3Fo%7D%20WHERE%20%7B%3Fs%20%3Fp%20%3Fo%7D&infer=true&timeout=5';
+    const expectedData = 'update=INSERT%20%7B%3Fs%20%3Fp%20%3Fo%7D%20WHERE%20%7B%3Fs%20%3Fp%20%3Fo%7D&infer=true&using-graph-uri=%3Chttp%3A%2F%2Fexample.org%2Fgraph1%3E&using-named-graph-uri=%3Chttp%3A%2F%2Fexample.org%2Fgraph2%3E&remove-graph-uri=%3Chttp%3A%2F%2Fexample.org%2Fgraph3%3E&insert-graph-uri=%3Chttp%3A%2F%2Fexample.org%2Fgraph4%3E&timeout=5';
     const expectedRequestConfig = HttpRequestBuilder.httpPost('/statements')
       .setData(expectedData)
       .setHeaders({


### PR DESCRIPTION
Add using-graph-uri, using-named-graph-uri, remove-graph-uri, insert-graph-uri to the UpdateQueryPayload as defined by RDF4J REST API.
https://rdf4j.eclipse.org/documentation/rest-api/