### PR TITLE
Remove @inheritDoc tag from constructors

### DIFF
--- a/src/parser/jsonld-parser.js
+++ b/src/parser/jsonld-parser.js
@@ -11,7 +11,7 @@ const JsonLdParser = require('jsonld-streaming-parser').JsonLdParser;
  */
 class JsonLDParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/n-quads-parser.js
+++ b/src/parser/n-quads-parser.js
@@ -11,7 +11,7 @@ const Parser = require('n3').Parser;
  */
 class NQuadsParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/n-triples-parser.js
+++ b/src/parser/n-triples-parser.js
@@ -11,7 +11,7 @@ const Parser = require('n3').Parser;
  */
 class NTriplesParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/n3-parser.js
+++ b/src/parser/n3-parser.js
@@ -11,7 +11,7 @@ const Parser = require('n3').Parser;
  */
 class N3Parser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/rdfxml-parser.js
+++ b/src/parser/rdfxml-parser.js
@@ -11,7 +11,7 @@ const RdfXmlParser = require('rdfxml-streaming-parser').RdfXmlParser;
  */
 class RDFXmlParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/sparql-json-result-parser.js
+++ b/src/parser/sparql-json-result-parser.js
@@ -19,7 +19,7 @@ import {SparqlJsonParser} from 'sparqljson-parse';
  */
 class SparqlJsonResultParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/sparql-xml-result-parser.js
+++ b/src/parser/sparql-xml-result-parser.js
@@ -19,7 +19,7 @@ import {SparqlXmlParser} from 'sparqlxml-parse';
  */
 class SparqlXmlResultParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/trig-parser.js
+++ b/src/parser/trig-parser.js
@@ -11,7 +11,7 @@ const Parser = require('n3').Parser;
  */
 class TriGParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/parser/turtle-parser.js
+++ b/src/parser/turtle-parser.js
@@ -11,7 +11,7 @@ const Parser = require('n3').Parser;
  */
 class TurtleParser extends ContentParser {
   /**
-   * @inheritDoc
+   * @param {Object} config is an object containing the parser configuration.
    */
   constructor(config) {
     super(config);

--- a/src/query/get-query-payload.js
+++ b/src/query/get-query-payload.js
@@ -59,7 +59,7 @@ const QUERY_TO_RESPONSE_TYPE_FORMATS_MAPPING = {
  */
 class GetQueryPayload extends QueryPayload {
   /**
-   * @inheritDoc
+   * Does basic initialization.
    */
   constructor() {
     super();

--- a/src/repository/rdf-repository-client.js
+++ b/src/repository/rdf-repository-client.js
@@ -37,7 +37,7 @@ const PATH_STATEMENTS = '/statements';
  */
 class RDFRepositoryClient extends BaseRepositoryClient {
   /**
-   * @inheritdoc
+   * @param {RepositoryClientConfig} repositoryClientConfig
    */
   constructor(repositoryClientConfig) {
     super(repositoryClientConfig);


### PR DESCRIPTION
The @inheritDoc tag put on constructors seems to break the typescript definition generation of that constructor.

The tag is replaced with appropriate comments.