### PR TITLE
Reduce code duplication

### DIFF
--- a/src/logging/logging-utils.js
+++ b/src/logging/logging-utils.js
@@ -1,0 +1,30 @@
+/**
+ * Utilities related to logging.
+ *
+ * @author Mihail Radkov
+ */
+class LoggingUtils {
+  /**
+   * Creates an object from the provided HTTP response that is suitable for
+   * structured logging.
+   *
+   * Any additional key-value entries from <code>params</code> will be assigned
+   * in the created payload object.
+   *
+   * @protected
+   * @param {HttpResponse} response the HTTP response.
+   * Used to get the execution time and the base URL
+   * @param {object} [params] additional parameters to be appended
+   * @return {object} the constructed payload object for logging
+   */
+  static getLogPayload(response, params = {}) {
+    const payload = {
+      elapsedTime: response.getElapsedTime(),
+      repositoryUrl: response.getBaseURL()
+    };
+    Object.assign(payload, params);
+    return payload;
+  }
+}
+
+module.exports = LoggingUtils;

--- a/src/model/term-converter.js
+++ b/src/model/term-converter.js
@@ -90,21 +90,22 @@ class TermConverter {
    * @public
    * @static
    * @param {Quad[]} quads the collection of quads to serialize to Turtle
-   * @return {Promise<string>} a promise that will be resolved to Turtle or Trig
+   * @return {string} a promise that will be resolved to Turtle or Trig
    * text or rejected if the quads cannot be serialized
    */
   static toString(quads) {
     const writer = TermConverter.getWriter();
     writer.addQuads(quads);
-    return new Promise((resolve, reject) => {
-      writer.end((error, result) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(result.trim());
-        }
-      });
+
+    let converted = '';
+    writer.end((error, result) => {
+      if (error) {
+        throw new Error(error);
+      } else {
+        converted = result.trim();
+      }
     });
+    return converted;
   }
 
   /**

--- a/src/repository/base-repository-client.js
+++ b/src/repository/base-repository-client.js
@@ -5,6 +5,7 @@ const RepositoryClientConfig =
   require('../repository/repository-client-config');
 const Iterable = require('../util/iterable');
 const HttpResponse = require('../http/http-response');
+const LoggingUtils = require('../logging/logging-utils');
 
 /**
  * Set of HTTP status codes for which requests could be re-attempted.
@@ -210,13 +211,8 @@ class BaseRepositoryClient {
    * @param {object} [params] additional parameters to be appended
    * @return {object} the constructed payload object for logging
    */
-  getLogPayload(response, params = {}) {
-    const payload = {
-      elapsedTime: response.getElapsedTime(),
-      repositoryUrl: response.getBaseURL()
-    };
-    Object.assign(payload, params);
-    return payload;
+  getLogPayload(response, params) {
+    return LoggingUtils.getLogPayload(response, params);
   }
 
   /**

--- a/src/repository/base-repository-client.js
+++ b/src/repository/base-repository-client.js
@@ -93,16 +93,6 @@ class BaseRepositoryClient {
   }
 
   /**
-   * Obtain a parser instance by type.
-   *
-   * @param {string} responseType
-   * @return {ContentParser}
-   */
-  getParser(responseType) {
-    return this.parserRegistry.get(responseType);
-  }
-
-  /**
    * Parses provided content with registered parser if there is one. Otherwise
    * returns the content untouched. If <code>contentType</code> is provided it
    * should be an instance of {@link RDFMimeType} enum and is used as a key

--- a/src/repository/rdf-repository-client.js
+++ b/src/repository/rdf-repository-client.js
@@ -405,8 +405,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    * @return {Promise<TransactionalRepositoryClient>} transactional client
    */
   beginTransaction(isolationLevel) {
-    return this.transactionService.beginTransaction(isolationLevel,
-      this.repositoryClientConfig);
+    return this.transactionService.beginTransaction(isolationLevel);
   }
 }
 

--- a/src/repository/rdf-repository-client.js
+++ b/src/repository/rdf-repository-client.js
@@ -69,12 +69,11 @@ class RDFRepositoryClient extends BaseRepositoryClient {
     const requestBuilder = HttpRequestBuilder.httpGet('/size')
       .addParam('context', TermConverter.toNTripleValues(context));
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {context}),
-          'Fetched size');
-        return response.getData();
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {context}),
+        'Fetched size');
+      return response.getData();
+    });
   }
 
   /**
@@ -87,11 +86,10 @@ class RDFRepositoryClient extends BaseRepositoryClient {
     const requestBuilder = HttpRequestBuilder.httpGet(PATH_NAMESPACES)
       .addAcceptHeader(RDFMimeType.SPARQL_RESULTS_JSON);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response), 'Fetched namespaces');
-        return this.mapNamespaceResponse(response.getData());
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response), 'Fetched namespaces');
+      return this.mapNamespaceResponse(response.getData());
+    });
   }
 
   /**
@@ -131,12 +129,11 @@ class RDFRepositoryClient extends BaseRepositoryClient {
     const namespaceUrl = `${PATH_NAMESPACES}/${prefix}`;
     const requestBuilder = HttpRequestBuilder.httpGet(namespaceUrl);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {prefix}),
-          'Fetched namespace');
-        return DataFactory.namedNode(response.getData());
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {prefix}),
+        'Fetched namespace');
+      return DataFactory.namedNode(response.getData());
+    });
   }
 
   /**
@@ -167,11 +164,10 @@ class RDFRepositoryClient extends BaseRepositoryClient {
       .httpPut(`${PATH_NAMESPACES}/${prefix}`)
       .setData(payload);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {prefix, namespace}),
-          'Saved namespace');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {prefix, namespace}),
+        'Saved namespace');
+    });
   }
 
   /**
@@ -196,11 +192,10 @@ class RDFRepositoryClient extends BaseRepositoryClient {
     const requestBuilder = HttpRequestBuilder
       .httpDelete(`${PATH_NAMESPACES}/${prefix}`);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {prefix}),
-          'Deleted namespace');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {prefix}),
+        'Deleted namespace');
+    });
   }
 
   /**
@@ -212,11 +207,10 @@ class RDFRepositoryClient extends BaseRepositoryClient {
   deleteNamespaces() {
     const requestBuilder = HttpRequestBuilder.httpDelete(PATH_NAMESPACES);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response),
-          'Deleted all namespaces');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response),
+        'Deleted all namespaces');
+    });
   }
 
   /**
@@ -246,16 +240,15 @@ class RDFRepositoryClient extends BaseRepositoryClient {
       requestBuilder.setResponseType('stream');
     }
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          subject: payload.getSubject(),
-          predicate: payload.getPredicate(),
-          object: payload.getObject(),
-          context: payload.getContext()
-        }), 'Fetched data');
-        return this.parse(response.getData(), payload.getResponseType());
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        subject: payload.getSubject(),
+        predicate: payload.getPredicate(),
+        object: payload.getObject(),
+        context: payload.getContext()
+      }), 'Fetched data');
+      return this.parse(response.getData(), payload.getResponseType());
+    });
   }
 
   /**
@@ -277,16 +270,15 @@ class RDFRepositoryClient extends BaseRepositoryClient {
       .addAcceptHeader(payload.getResponseType())
       .addContentTypeHeader(payload.getContentType());
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          query: payload.getQuery(),
-          queryType: payload.getQueryType()
-        }), 'Queried data');
-        return this.parse(response.getData(), payload.getResponseType(), {
-          queryType: payload.getQueryType()
-        });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        query: payload.getQuery(),
+        queryType: payload.getQueryType()
+      }), 'Queried data');
+      return this.parse(response.getData(), payload.getResponseType(), {
+        queryType: payload.getQueryType()
       });
+    });
   }
 
   /**
@@ -312,11 +304,10 @@ class RDFRepositoryClient extends BaseRepositoryClient {
       .setData(payload.getParams())
       .addContentTypeHeader(payload.getContentType());
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response,
-          {query: payload.getQuery()}), 'Performed update');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response,
+        {query: payload.getQuery()}), 'Performed update');
+    });
   }
 
   /**
@@ -446,7 +437,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
       requestBuilder.setMethod('post');
     }
 
-    return this.execute((http) => http.request(requestBuilder));
+    return this.execute(requestBuilder);
   }
 
   /**
@@ -476,15 +467,14 @@ class RDFRepositoryClient extends BaseRepositoryClient {
         context: TermConverter.toNTripleValues(contexts)
       });
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          subject,
-          predicate,
-          object,
-          contexts
-        }), 'Deleted statements');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        subject,
+        predicate,
+        object,
+        contexts
+      }), 'Deleted statements');
+    });
   }
 
   /**
@@ -495,11 +485,10 @@ class RDFRepositoryClient extends BaseRepositoryClient {
    */
   deleteAllStatements() {
     const requestBuilder = HttpRequestBuilder.httpDelete(PATH_STATEMENTS);
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response),
-          'Deleted all statements');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response),
+        'Deleted all statements');
+    });
   }
 
   /**
@@ -529,16 +518,15 @@ class RDFRepositoryClient extends BaseRepositoryClient {
         infer: payload.getInference()
       });
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          subject: payload.getSubject(),
-          predicate: payload.getPredicate(),
-          object: payload.getObject(),
-          context: payload.getContext()
-        }), 'Downloaded data');
-        return response.getData();
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        subject: payload.getSubject(),
+        predicate: payload.getPredicate(),
+        object: payload.getObject(),
+        context: payload.getContext()
+      }), 'Downloaded data');
+      return response.getData();
+    });
   }
 
   /**
@@ -680,7 +668,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
         context: TermConverter.toNTripleValues(context)
       });
 
-    return this.execute((http) => http.request(requestBuilder));
+    return this.execute(requestBuilder);
   }
 
   /**
@@ -708,7 +696,7 @@ class RDFRepositoryClient extends BaseRepositoryClient {
         context: TermConverter.toNTripleValues(context)
       });
 
-    return this.execute((http) => http.request(requestBuilder));
+    return this.execute(requestBuilder);
   }
 
   /**
@@ -729,22 +717,21 @@ class RDFRepositoryClient extends BaseRepositoryClient {
     const requestBuilder = HttpRequestBuilder.httpPost('/transactions')
       .addParam('isolation-level', isolationLevel);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        const locationUrl = response.getHeaders()['location'];
-        if (StringUtils.isBlank(locationUrl)) {
-          this.logger.error(this.getLogPayload(response, {isolationLevel}),
-            'Cannot obtain transaction ID');
-          return Promise.reject(new Error('Couldn\'t obtain transaction ID'));
-        }
+    return this.execute(requestBuilder).then((response) => {
+      const locationUrl = response.getHeaders()['location'];
+      if (StringUtils.isBlank(locationUrl)) {
+        this.logger.error(this.getLogPayload(response, {isolationLevel}),
+          'Cannot obtain transaction ID');
+        return Promise.reject(new Error('Couldn\'t obtain transaction ID'));
+      }
 
-        const config = this.getTransactionalClientConfig(locationUrl);
-        const transactionClient = new TransactionalRepositoryClient(config);
+      const config = this.getTransactionalClientConfig(locationUrl);
+      const transactionClient = new TransactionalRepositoryClient(config);
 
-        this.logger.debug(this.getLogPayload(response, {isolationLevel}),
-          'Started transaction');
-        return transactionClient;
-      });
+      this.logger.debug(this.getLogPayload(response, {isolationLevel}),
+        'Started transaction');
+      return transactionClient;
+    });
   }
 
   /**

--- a/src/service/download-service.js
+++ b/src/service/download-service.js
@@ -1,0 +1,60 @@
+const Service = require('./service');
+const HttpRequestBuilder = require('../http/http-request-builder');
+const ServiceRequest = require('./service-request');
+const PATH_STATEMENTS = require('./service-paths').PATH_STATEMENTS;
+
+const LoggingUtils = require('../logging/logging-utils');
+const TermConverter = require('../model/term-converter');
+
+/**
+ * Service for downloading data via {@link GetStatementsPayload}.
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class DownloadService extends Service {
+  /**
+   * Fetch rdf data from statements endpoint using provided parameters.
+   *
+   * The request is configured so that expected response should be a readable
+   * stream.
+   *
+   * Provided request params will be automatically converted to N-Triples if
+   * they are not already encoded as such.
+   *
+   * @param {GetStatementsPayload} payload is an object holding request params
+   *
+   * @return {ServiceRequest} a service request that will resolve to a readable
+   * stream to which the client can subscribe and consume the emitted strings
+   * depending on the provided response type as soon as they are available.
+   */
+  download(payload) {
+    const requestBuilder = HttpRequestBuilder.httpGet(PATH_STATEMENTS)
+      .addAcceptHeader(payload.getResponseType())
+      .setResponseType('stream')
+      .setParams({
+        subj: TermConverter.toNTripleValue(payload.getSubject()),
+        pred: TermConverter.toNTripleValue(payload.getPredicate()),
+        obj: TermConverter.toNTripleValue(payload.getObject()),
+        context: TermConverter.toNTripleValues(payload.getContext()),
+        infer: payload.getInference()
+      });
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response,
+          requestBuilder.getParams()), 'Downloaded data');
+        return response.getData();
+      });
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getServiceName() {
+    return 'DownloadService';
+  }
+}
+
+module.exports = DownloadService;

--- a/src/service/namespace-service.js
+++ b/src/service/namespace-service.js
@@ -1,0 +1,187 @@
+const Service = require('./service');
+const HttpRequestBuilder = require('../http/http-request-builder');
+const ServiceRequest = require('./service-request');
+const PATH_NAMESPACES = require('./service-paths').PATH_NAMESPACES;
+
+const RDFMimeType = require('../http/rdf-mime-type');
+const Namespace = require('../model/namespace');
+
+const LoggingUtils = require('../logging/logging-utils');
+const StringUtils = require('../util/string-utils');
+
+const DataFactory = require('n3').DataFactory;
+const NamedNode = DataFactory.internal.NamedNode;
+
+/**
+ * Service for namespace management.
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class NamespaceService extends Service {
+  /**
+   * Retrieves all present namespaces as a collection of {@link Namespace}.
+   *
+   * @return {ServiceRequest} a service request resolving to a collection of
+   * {@link Namespace}
+   */
+  getNamespaces() {
+    const requestBuilder = HttpRequestBuilder.httpGet(PATH_NAMESPACES)
+      .addAcceptHeader(RDFMimeType.SPARQL_RESULTS_JSON);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response),
+          'Fetched namespaces');
+        return this.mapNamespaceResponse(response.getData());
+      });
+    });
+  }
+
+  /**
+   * Maps the response data from the namespaces request into {@link Namespace}.
+   *
+   * @private
+   *
+   * @param {object} responseData the data to map
+   *
+   * @return {Namespace[]} the mapped namespaces
+   */
+  mapNamespaceResponse(responseData) {
+    return responseData.results.bindings.map((binding) => {
+      const prefix = binding.prefix.value;
+      const namespace = DataFactory.namedNode(binding.namespace.value);
+      return new Namespace(prefix, namespace);
+    });
+  }
+
+  /**
+   * Retrieves the namespace for the given prefix as {@link NamedNode}.
+   *
+   * For example if <code>rdfs</code> is provided as prefix that would result in
+   * a {@link NamedNode} corresponding to following namespace:
+   * <code>http://www.w3.org/2000/01/rdf-schema#</code>
+   *
+   * Note: This method should be invoked only with prefixes. Anything else would
+   * result in an error from the server.
+   *
+   * @param {string} prefix prefix of the namespace to be retrieved
+   *
+   * @return {ServiceRequest} service request resolving to {@link NamedNode}
+   *
+   * @throws {Error} if the prefix parameter is not supplied
+   */
+  getNamespace(prefix) {
+    if (StringUtils.isBlank(prefix)) {
+      throw new Error('Parameter prefix is required!');
+    }
+
+    const namespaceUrl = `${PATH_NAMESPACES}/${prefix}`;
+    const requestBuilder = HttpRequestBuilder.httpGet(namespaceUrl);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {prefix}),
+          'Fetched namespace');
+
+        return DataFactory.namedNode(response.getData());
+      });
+    });
+  }
+
+  /**
+   * Creates or updates the namespace for the given prefix.
+   *
+   * If the provided prefix or namespace parameter is not a string or
+   * {@link NamedNode} then the method will throw an error.
+   *
+   * @param {string} prefix prefix of the namespace to be created/updated
+   * @param {string|NamedNode} namespace the namespace to be created/updated
+   *
+   * @return {ServiceRequest} service request that will be resolved if the
+   * create/update request is successful
+   *
+   * @throws {Error} if the prefix or namespace parameter are not provided
+   */
+  saveNamespace(prefix, namespace) {
+    if (StringUtils.isBlank(prefix)) {
+      throw new Error('Parameter prefix is required!');
+    }
+
+    let payload = namespace;
+    if (namespace instanceof NamedNode) {
+      payload = namespace.value;
+    } else if (StringUtils.isBlank(namespace)) {
+      throw new Error('Parameter namespace is required!');
+    }
+
+    const requestBuilder = HttpRequestBuilder
+      .httpPut(`${PATH_NAMESPACES}/${prefix}`)
+      .setData(payload);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response,
+          {prefix, namespace}), 'Saved namespace');
+      });
+    });
+  }
+
+  /**
+   * Deletes a namespace that corresponds to the given prefix.
+   *
+   * For example if <code>rdfs</code> is provided as prefix that would delete
+   * the following namespace: <code>http://www.w3.org/2000/01/rdf-schema#</code>
+   *
+   * Note: This method should be invoked only with prefixes. Anything else would
+   * result in an error from the server.
+   *
+   * @param {string} prefix prefix of the namespace to be deleted
+   *
+   * @return {Promise<void>} promise that will be resolved if the deletion is
+   * successful
+   *
+   * @throws {Error} if the prefix parameter is not provided
+   */
+  deleteNamespace(prefix) {
+    if (StringUtils.isBlank(prefix)) {
+      throw new Error('Parameter prefix is required!');
+    }
+
+    const requestBuilder = HttpRequestBuilder
+      .httpDelete(`${PATH_NAMESPACES}/${prefix}`);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {prefix}),
+          'Deleted namespace');
+      });
+    });
+  }
+
+  /**
+   * Deletes all namespace declarations in the repository.
+   *
+   * @return {Promise<void>} promise that will be resolved after
+   * successful deletion
+   */
+  deleteNamespaces() {
+    const requestBuilder = HttpRequestBuilder.httpDelete(PATH_NAMESPACES);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response),
+          'Deleted all namespaces');
+      });
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getServiceName() {
+    return 'NamespaceService';
+  }
+}
+
+module.exports = NamespaceService;

--- a/src/service/query-service.js
+++ b/src/service/query-service.js
@@ -1,0 +1,123 @@
+const Service = require('./service');
+const HttpRequestBuilder = require('../http/http-request-builder');
+const ServiceRequest = require('./service-request');
+const PATH_STATEMENTS = require('./service-paths').PATH_STATEMENTS;
+
+const LoggingUtils = require('../logging/logging-utils');
+
+/**
+ * Service for executing queries via {@link GetQueryPayload} or
+ * {@link UpdateQueryPayload}.
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class QueryService extends Service {
+  /**
+   * Instantiates the query service.
+   *
+   * @param {Function} httpRequestExecutor used to execute HTTP requests
+   * @param {Function} parseExecutor function that will parse provided data
+   */
+  constructor(httpRequestExecutor, parseExecutor) {
+    super(httpRequestExecutor);
+    this.parseExecutor = parseExecutor;
+  }
+
+  /**
+   * Executes request to query a repository.
+   *
+   * Only POST request with a valid QueryPayload is supported.
+   *
+   * @param {GetQueryPayload} payload is an object holding request parameters
+   * required by the query POST endpoint.
+   *
+   * @return {ServiceRequest} a service request that will resolve to a readable
+   * stream to which the client can subscribe and consume
+   * the emitted strings or Quads depending on the provided response type as
+   * soon as they are available.
+   *
+   * @throws {Error} if the payload is misconfigured
+   */
+  query(payload) {
+    const requestBuilder = HttpRequestBuilder.httpPost('')
+      .setData(payload.getParams())
+      .setResponseType('stream')
+      .addAcceptHeader(payload.getResponseType())
+      .addContentTypeHeader(payload.getContentType());
+
+    return new ServiceRequest(requestBuilder,
+      () => this.executeQuery(payload, requestBuilder));
+  }
+
+  /**
+   * Executes a query request with the supplied payload and request builder.
+   *
+   * @private
+   *
+   * @param {GetQueryPayload} payload an object holding request parameters
+   * required by the query POST endpoint.
+   * @param {HttpRequestBuilder} requestBuilder builder containing the request
+   * parameters and data
+   *
+   * @return {Promise} promise resolving to parsed query response
+   *
+   * @throws {Error} if the payload is misconfigured
+   */
+  executeQuery(payload, requestBuilder) {
+    return this.httpRequestExecutor(requestBuilder).then((response) => {
+      const logPayload = LoggingUtils.getLogPayload(response, {
+        query: payload.getQuery(),
+        queryType: payload.getQueryType()
+      });
+      this.logger.debug(logPayload, 'Queried data');
+
+      const parserConfig = {queryType: payload.getQueryType()};
+      return this.parseExecutor(response.getData(), payload.getResponseType(),
+        parserConfig);
+    });
+  }
+
+  /**
+   * Executes a request with a sparql query against <code>/statements</code>
+   * endpoint to update repository data.
+   *
+   * If <code>contentType</code> is set to
+   * <code>application/x-www-form-urlencoded</code> then query and request
+   * parameters from the payload are encoded as query string and sent as request
+   * body.
+   *
+   * If <code>contentType</code> is set to
+   * <code>application/sparql-update</code> then the query is sent unencoded as
+   * request body.
+   *
+   * @param {UpdateQueryPayload} payload
+   *
+   * @return {ServiceRequest} service request that will be resolved if the
+   * update is successful or rejected in case of failure
+   *
+   * @throws {Error} if the payload is misconfigured
+   */
+  update(payload) {
+    const requestBuilder = HttpRequestBuilder.httpPost(PATH_STATEMENTS)
+      .setData(payload.getParams())
+      .addContentTypeHeader(payload.getContentType());
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        const logPayload = LoggingUtils.getLogPayload(response,
+          {query: payload.getQuery()});
+        this.logger.debug(logPayload, 'Performed update');
+      });
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getServiceName() {
+    return 'StatementsService';
+  }
+}
+
+module.exports = QueryService;

--- a/src/service/repository-service.js
+++ b/src/service/repository-service.js
@@ -1,0 +1,51 @@
+const Service = require('./service');
+const HttpRequestBuilder = require('../http/http-request-builder');
+const ServiceRequest = require('./service-request');
+const PATH_SIZE = require('./service-paths').PATH_SIZE;
+
+const TermConverter = require('../model/term-converter');
+const LoggingUtils = require('../logging/logging-utils');
+
+/**
+ * Service for working repositories.
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class RepositoryService extends Service {
+  /**
+   * Retrieves the size of the repository.
+   *
+   * Effectively returns how much statements are in the repository.
+   *
+   * If one or multiple context are provided, the operation will be restricted
+   * upon each of them.
+   *
+   * @param {string|string[]} [context] context or contexts to restrict the
+   * size calculation. Will be encoded as N-Triple if it is not already one
+   *
+   * @return {ServiceRequest} a service request resolving to the total number of
+   * statements in the repository
+   */
+  getSize(context) {
+    const requestBuilder = HttpRequestBuilder.httpGet(PATH_SIZE)
+      .addParam('context', TermConverter.toNTripleValues(context));
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        const logPayload = LoggingUtils.getLogPayload(response, {context});
+        this.logger.debug(logPayload, 'Fetched size');
+        return response.getData();
+      });
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getServiceName() {
+    return 'RepositoryService';
+  }
+}
+
+module.exports = RepositoryService;

--- a/src/service/service-paths.js
+++ b/src/service/service-paths.js
@@ -1,0 +1,34 @@
+/**
+ * Defines a path segment for statements REST endpoint
+ *
+ * @type {string}
+ */
+const PATH_STATEMENTS = '/statements';
+
+/**
+ * Defines the path segment for namespaces REST endpoint
+ *
+ * @type {string}
+ */
+const PATH_NAMESPACES = '/namespaces';
+
+/**
+ * Defines a path segment for transactions REST endpoint.
+ *
+ * @type {string}
+ */
+const PATH_TRANSACTIONS = '/transactions';
+
+/**
+ * Defines a path segment for size REST endpoint.
+ *
+ * @type {string}
+ */
+const PATH_SIZE = '/size';
+
+module.exports = {
+  PATH_STATEMENTS,
+  PATH_NAMESPACES,
+  PATH_TRANSACTIONS,
+  PATH_SIZE
+};

--- a/src/service/service-request.js
+++ b/src/service/service-request.js
@@ -1,0 +1,44 @@
+/**
+ * Wrapper class for service request.
+ *
+ * Contains the request builder and the executor function that will perform
+ * the request and produce the results.
+ *
+ * This wrapper allows to modify the request builder before executing it,
+ * preserving any chained promises to the executor.
+ *
+ * @author Mihail Radkov
+ */
+class ServiceRequest {
+  /**
+   * Instantiates the request with the supplied builder and executor.
+   *
+   * @param {HttpRequestBuilder} httpRequestBuilder builder carrying
+   * the request data and params
+   * @param {Function} requestExecutor executor for HTTP requests
+   */
+  constructor(httpRequestBuilder, requestExecutor) {
+    this.httpRequestBuilder = httpRequestBuilder;
+    this.requestExecutor = requestExecutor;
+  }
+
+  /**
+   * Returns the request builder.
+   *
+   * @return {HttpRequestBuilder}
+   */
+  getHttpRequestBuilder() {
+    return this.httpRequestBuilder;
+  }
+
+  /**
+   * Triggers service request execution.
+   *
+   * @return {Promise}
+   */
+  execute() {
+    return this.requestExecutor();
+  }
+}
+
+module.exports = ServiceRequest;

--- a/src/service/service.js
+++ b/src/service/service.js
@@ -1,0 +1,47 @@
+const ConsoleLogger = require('../logging/console-logger');
+
+/**
+ * Base service class containing common and utility logic for
+ * extending services.
+ *
+ * @class
+ * @abstract
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class Service {
+  /**
+   * Instantiates the service with the provided HTTP request executor function.
+   *
+   * @param {Function} httpRequestExecutor used to execute HTTP requests
+   */
+  constructor(httpRequestExecutor) {
+    this.httpRequestExecutor = httpRequestExecutor;
+    this.initLogger();
+  }
+
+  /**
+   * Instantiates the service's logger.
+   *
+   * @private
+   */
+  initLogger() {
+    this.logger = new ConsoleLogger({
+      name: this.getServiceName()
+    });
+  }
+
+  /**
+   * Returns the service's name.
+
+   * @abstract
+   *
+   * @return {string} the name
+   */
+  getServiceName() {
+    throw new Error('Must be overridden!');
+  }
+}
+
+module.exports = Service;

--- a/src/service/statements-service.js
+++ b/src/service/statements-service.js
@@ -1,0 +1,290 @@
+const Service = require('./service');
+const HttpRequestBuilder = require('../http/http-request-builder');
+const ServiceRequest = require('./service-request');
+const PATH_STATEMENTS = require('./service-paths').PATH_STATEMENTS;
+
+const RDFMimeType = require('../http/rdf-mime-type');
+const StringUtils = require('../util/string-utils');
+const TermConverter = require('../model/term-converter');
+const LoggingUtils = require('../logging/logging-utils');
+const CommonUtils = require('../util/common-utils');
+
+/**
+ * Service for reading, inserting or deleting repository statements.
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class StatementsService extends Service {
+  /**
+   * Instantiates the service with the supplied executor and parser utils.
+   *
+   * @param {Function} httpRequestExecutor executor for HTTP requests
+   * @param {ParserRegistry} parserRegistry registry of available parsers
+   * @param {Function} parseExecutor function that will parse provided data
+   */
+  constructor(httpRequestExecutor, parserRegistry, parseExecutor) {
+    super(httpRequestExecutor);
+    this.parserRegistry = parserRegistry;
+    this.parseExecutor = parseExecutor;
+  }
+
+  /**
+   * Fetch rdf data from statements endpoint using provided parameters.
+   *
+   * Provided values will be automatically converted to N-Triples if they are
+   * not already encoded as such.
+   *
+   * @param {GetStatementsPayload} payload is an object holding the request
+   * parameters.
+   *
+   * @return {ServiceRequest} service request that resolves to plain string or
+   * Quad according to provided response type.
+   */
+  get(payload) {
+    const requestBuilder = HttpRequestBuilder.httpGet(PATH_STATEMENTS)
+      .setParams({
+        subj: TermConverter.toNTripleValue(payload.getSubject()),
+        pred: TermConverter.toNTripleValue(payload.getPredicate()),
+        obj: TermConverter.toNTripleValue(payload.getObject()),
+        context: TermConverter.toNTripleValues(payload.getContext()),
+        infer: payload.getInference()
+      })
+      .addAcceptHeader(payload.getResponseType());
+
+    const parser = this.parserRegistry.get(payload.getResponseType());
+    if (parser && parser.isStreaming()) {
+      requestBuilder.setResponseType('stream');
+    }
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          subject: payload.getSubject(),
+          predicate: payload.getPredicate(),
+          object: payload.getObject(),
+          context: payload.getContext()
+        }), 'Fetched data');
+        return this.parseExecutor(response.getData(),
+          payload.getResponseType());
+      });
+    });
+  }
+
+  /**
+   * Saves the provided statement payload in the repository.
+   *
+   * The payload will be converted to a quad or a collection of quads in case
+   * there are multiple contexts.
+   *
+   * After the conversion, the produced quad(s) will be serialized to Turtle or
+   * Trig format and send to the repository as payload.
+   *
+   * See {@link #addQuads()}.
+   *
+   * @param {AddStatementPayload} payload holding request parameters
+   *
+   * @return {ServiceRequest} service request that will resolve if the addition
+   * is successful or reject in case of failure
+   *
+   * @throws {Error} if the payload is not provided or the payload has null
+   * subject, predicate and/or object
+   */
+  add(payload) {
+    if (!payload) {
+      throw new Error('Cannot add statement without payload');
+    }
+
+    const subject = payload.getSubject();
+    const predicate = payload.getPredicate();
+    const object = payload.getObject();
+    const context = payload.getContext();
+
+    if (CommonUtils.hasNullArguments(subject, predicate, object)) {
+      throw new Error('Cannot add statement with null ' +
+        'subject, predicate or object');
+    }
+
+    let quads;
+    if (payload.isLiteral()) {
+      quads = TermConverter.getLiteralQuads(subject, predicate, object, context,
+        payload.getDataType(), payload.getLanguage());
+    } else {
+      quads = TermConverter.getQuads(subject, predicate, object, context);
+    }
+
+    return this.addQuads(quads, payload.getContext(), payload.getBaseURI());
+  }
+
+  /**
+   * Serializes the provided quads to Turtle format and sends them to the
+   * repository as payload.
+   *
+   * If any of the quads have a graph, then the text will be serialized to the
+   * Trig format which is an extended version of Turtle supporting contexts.
+   *
+   * @param {Quad[]} quads collection of quads to be sent as Turtle/Trig text
+   * @param {string|string[]} [context] restricts the insertion to the given
+   * context. Will be encoded as N-Triple if it is not already one
+   * @param {string} [baseURI] used to resolve relative URIs in the data
+   *
+   * @return {ServiceRequest} service request that will be resolved if the
+   * addition is successful or rejected in case of failure
+   *
+   * @throws {Error} if no quads are provided or if they cannot be converted
+   */
+  addQuads(quads, context, baseURI) {
+    const requestBuilder = this.getInsertRequest(quads, context, baseURI,
+      false);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          quads,
+          context,
+          baseURI
+        }), 'Inserted statements');
+      });
+    });
+  }
+
+  /**
+   * Overwrites the repository's data by serializing the provided quads to
+   * Turtle format and sending them to the repository as payload.
+   *
+   * If any of the quads have a graph, then the text will be serialized to the
+   * Trig format which is an extended version of Turtle supporting contexts.
+   *
+   * The overwrite will be restricted if the context parameter is specified.
+   *
+   * @param {Quad[]} quads collection of quads to be sent as Turtle/Trig text
+   * @param {string|string[]} [context] restricts the insertion to the given
+   * context. Will be encoded as N-Triple if it is not already one
+   * @param {string} [baseURI] used to resolve relative URIs in the data
+   *
+   * @return {ServiceRequest} service request that will be resolved if the
+   * overwrite is successful or rejected in case of failure
+   *
+   * @throws {Error} if no quads are provided or if they cannot be converted
+   */
+  putQuads(quads, context, baseURI) {
+    const requestBuilder = this.getInsertRequest(quads, context, baseURI, true);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          quads,
+          context,
+          baseURI
+        }), 'Overwritten statements');
+      });
+    });
+  }
+
+  /**
+   * Constructs HttpRequestBuilder from the provided parameters for saving or
+   * overwriting statements.
+   *
+   * @private
+   *
+   * @param {Quad[]} quads collection of quads to be sent as Turtle/Trig text
+   * @param {string|string[]} [context] restricts the insertion to the given
+   * context. Will be encoded as N-Triple if it is not already one
+   * @param {string} [baseURI] used to resolve relative URIs in the data
+   * @param {boolean} overwrite defines if the data should overwrite the repo
+   * data or not
+   *
+   * @return {HttpRequestBuilder} promise resolving after the data has
+   * been inserted successfully or an error if not
+   *
+   * @throws {Error} if no quads are provided or if they cannot be converted
+   */
+  getInsertRequest(quads, context, baseURI, overwrite) {
+    const converted = TermConverter.toString(quads);
+    if (StringUtils.isBlank(converted)) {
+      throw new Error('Turtle/trig data is required when adding statements');
+    }
+
+    const requestBuilder = new HttpRequestBuilder()
+      .setUrl(PATH_STATEMENTS)
+      .setData(converted)
+      .addContentTypeHeader(RDFMimeType.TRIG)
+      .setParams({
+        baseURI,
+        context: TermConverter.toNTripleValues(context)
+      });
+
+    if (overwrite) {
+      requestBuilder.setMethod('put');
+    } else {
+      requestBuilder.setMethod('post');
+    }
+
+    return requestBuilder;
+  }
+
+  /**
+   * Deletes statements in the repository based on the provided subject,
+   * predicate, object and or contexts. Each of them is optional and acts as
+   * statements filter which effectively narrows the scope of the deletion.
+   *
+   * Providing context or contexts will restricts the operation to one or more
+   * specific contexts in the repository.
+   *
+   * Provided values will be automatically converted to N-Triples if they are
+   * not already encoded as such.
+   *
+   * @param {String} [subject] resource subject
+   * @param {String} [predicate] resource predicate
+   * @param {String} [object] resource object
+   * @param {String[]|String} [contexts] resource or resources context
+   *
+   * @return {ServiceRequest} service request that will be resolved if the
+   * deletion is successful or rejected in case of failure
+   */
+  deleteStatements(subject, predicate, object, contexts) {
+    const requestBuilder = HttpRequestBuilder.httpDelete(PATH_STATEMENTS)
+      .setParams({
+        subj: TermConverter.toNTripleValue(subject),
+        pred: TermConverter.toNTripleValue(predicate),
+        obj: TermConverter.toNTripleValue(object),
+        context: TermConverter.toNTripleValues(contexts)
+      });
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          subject,
+          predicate,
+          object,
+          contexts
+        }), 'Deleted statements');
+      });
+    });
+  }
+
+  /**
+   * Deletes all statements in the repository.
+   *
+   * @return {ServiceRequest} service request that will be resolved if the
+   * deletion is successful or rejected in case of failure
+   */
+  deleteAllStatements() {
+    const requestBuilder = HttpRequestBuilder.httpDelete(PATH_STATEMENTS);
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response),
+          'Deleted all statements');
+      });
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getServiceName() {
+    return 'StatementsService';
+  }
+}
+
+module.exports = StatementsService;

--- a/src/service/transaction-service.js
+++ b/src/service/transaction-service.js
@@ -1,0 +1,97 @@
+const Service = require('./service');
+const HttpRequestBuilder = require('../http/http-request-builder');
+const PATH_TRANSACTIONS = require('./service-paths').PATH_TRANSACTIONS;
+
+const LoggingUtils = require('../logging/logging-utils');
+const StringUtils = require('../util/string-utils');
+
+const RepositoryClientConfig =
+  require('../repository/repository-client-config');
+const TransactionalRepositoryClient =
+  require('../transaction/transactional-repository-client');
+
+/**
+ * Service for working with the transactions endpoint.
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class TransactionService extends Service {
+  /**
+   * Instantiates the transaction service wioth the supplied executor and
+   * repository client config.
+   *
+   * @param {Function} httpRequestExecutor used to execute HTTP requests
+   * @param {RepositoryClientConfig} repositoryClientConfig used to create
+   * transaction client configurations
+   */
+  constructor(httpRequestExecutor, repositoryClientConfig) {
+    super(httpRequestExecutor);
+    this.repositoryClientConfig = repositoryClientConfig;
+  }
+
+  /**
+   * Starts a transaction and produces a {@link TransactionalRepositoryClient}.
+   *
+   * The transactions ID is extracted from the <code>location</code> header and
+   * is used as  endpoint for the produced TransactionalRepositoryClient.
+   *
+   * If no transaction isolation level is provided, the server will use its
+   * default isolation level.
+   *
+   * @param {string} [isolationLevel] an optional parameter to specify the
+   * transaction's level of isolation; for possible values see
+   * {@link TransactionIsolationLevel}
+   *
+   * @return {Promise<TransactionalRepositoryClient>} transactional client
+   */
+  beginTransaction(isolationLevel) {
+    const requestBuilder = HttpRequestBuilder.httpPost(PATH_TRANSACTIONS)
+      .addParam('isolation-level', isolationLevel);
+
+    return this.httpRequestExecutor(requestBuilder).then((response) => {
+      const locationUrl = response.getHeaders()['location'];
+      if (StringUtils.isBlank(locationUrl)) {
+        this.logger.error(LoggingUtils.getLogPayload(response,
+          {isolationLevel}), 'Cannot obtain transaction ID');
+        return Promise.reject(new Error('Couldn\'t obtain transaction ID'));
+      }
+
+      const config = this.getTransactionalClientConfig(locationUrl);
+      const transactionClient = new TransactionalRepositoryClient(config);
+
+      this.logger.debug(LoggingUtils.getLogPayload(response, {isolationLevel}),
+        'Started transaction');
+      return transactionClient;
+    });
+  }
+
+  /**
+   * Builds client configuration for transactional repository out of the
+   * provided repository client config and the supplied location URL.
+   *
+   * @private
+   *
+   * @param {string} locationUrl the url for the transactional repo endpoint
+   *
+   * @return {RepositoryClientConfig} the built transaction client config
+   */
+  getTransactionalClientConfig(locationUrl) {
+    const config = this.repositoryClientConfig;
+    return new RepositoryClientConfig()
+      .setEndpoints([locationUrl])
+      .setHeaders(config.getHeaders())
+      .setDefaultRDFMimeType(config.getDefaultRDFMimeType())
+      .setReadTimeout(config.getReadTimeout())
+      .setWriteTimeout(config.getWriteTimeout());
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getServiceName() {
+    return 'TransactionService';
+  }
+}
+
+module.exports = TransactionService;

--- a/src/service/upload-service.js
+++ b/src/service/upload-service.js
@@ -1,0 +1,215 @@
+const Service = require('./service');
+const HttpRequestBuilder = require('../http/http-request-builder');
+const ServiceRequest = require('./service-request');
+const PATH_STATEMENTS = require('./service-paths').PATH_STATEMENTS;
+
+const TermConverter = require('../model/term-converter');
+const LoggingUtils = require('../logging/logging-utils');
+const FileUtils = require('../util/file-utils');
+
+/**
+ * Service for uploading data streams.
+ *
+ * @author Mihail Radkov
+ * @author Svilen Velikov
+ */
+class UploadService extends Service {
+  /**
+   * Executes a POST request against the <code>/statements</code> endpoint. The
+   * statements which have to be added are provided through a readable stream.
+   * This method is useful for library client who wants to upload a big data set
+   * into the repository.
+   *
+   * @param {ReadableStream} readStream
+   * @param {string} contentType is one of RDF mime type formats,
+   *                application/x-rdftransaction' for a transaction document or
+   *                application/x-www-form-urlencoded
+   * @param {NamedNode|string} [context] optional context to restrict the
+   * operation. Will be encoded as N-Triple if it is not already one
+   * @param {string} [baseURI] optional uri against which any relative URIs
+   * found in the data would be resolved.
+   *
+   * @return {ServiceRequest} a service request that will be resolved when the
+   * stream has been successfully consumed by the server
+   */
+  upload(readStream, contentType, context, baseURI) {
+    const requestBuilder = this.getUploadRequest(readStream, contentType,
+      context, baseURI);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          contentType,
+          context,
+          baseURI
+        }), 'Uploaded data stream');
+      });
+    });
+  }
+
+  /**
+   * Executes a PUT request against the <code>/statements</code> endpoint. The
+   * statements which have to be updated are provided through a readable stream.
+   * This method is useful for overriding large set of statements that might be
+   * provided as a readable stream e.g. reading from file.
+   *
+   * @param {ReadableStream} readStream
+   * @param {string} contentType
+   * @param {NamedNode|string} context restrict the operation. Will be encoded
+   * as N-Triple if it is not already one
+   * @param {string} [baseURI] optional uri against which any relative URIs
+   * found in the data would be resolved.
+   *
+   * @return {ServiceRequest} a service request that will be resolved when the
+   * stream has been successfully consumed by the server
+   */
+  overwrite(readStream, contentType, context, baseURI) {
+    const requestBuilder = this.getOverwriteRequest(readStream, contentType,
+      context, baseURI);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          contentType,
+          context,
+          baseURI
+        }), 'Overwritten data stream');
+      });
+    });
+  }
+
+  /**
+   * Uploads the file specified by the provided file path to the server.
+   *
+   * See {@link #upload}
+   *
+   * @param {string} filePath path to a file to be streamed to the server
+   * @param {string} contentType MIME type of the file's content
+   * @param {string|string[]} [context] restricts the operation to the given
+   * context. Will be encoded as N-Triple if it is not already one
+   * @param {string} [baseURI] used to resolve relative URIs in the data
+   *
+   * @return {ServiceRequest} a service request that will be resolved when the
+   * file has been successfully consumed by the server
+   */
+  addFile(filePath, contentType, context, baseURI) {
+    const fileStream = FileUtils.getReadStream(filePath);
+    const requestBuilder = this.getUploadRequest(fileStream, contentType,
+      context, baseURI);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          filePath,
+          contentType,
+          context,
+          baseURI
+        }), 'Uploaded file');
+      });
+    });
+  }
+
+  /**
+   * Uploads the file specified by the provided file path to the server
+   * overwriting any data in the server's repository.
+   *
+   * The overwrite will be restricted if the context parameter is specified.
+   *
+   * See {@link #overwrite}
+   *
+   * @param {string} filePath path to a file to be streamed to the server
+   * @param {string} contentType MIME type of the file's content
+   * @param {string} [context] restricts the operation to the given context.
+   * Will be encoded as N-Triple if it is not already one
+   * @param {string} [baseURI] used to resolve relative URIs in the data
+   *
+   * @return {ServiceRequest} a service request that will be resolved when the
+   * file has been successfully consumed by the server
+   */
+  putFile(filePath, contentType, context, baseURI) {
+    const fileStream = FileUtils.getReadStream(filePath);
+    const requestBuilder = this.getOverwriteRequest(fileStream, contentType,
+      context, baseURI);
+
+    return new ServiceRequest(requestBuilder, () => {
+      return this.httpRequestExecutor(requestBuilder).then((response) => {
+        this.logger.debug(LoggingUtils.getLogPayload(response, {
+          filePath,
+          contentType,
+          context,
+          baseURI
+        }), 'Overwritten data from file');
+      });
+    });
+  }
+
+  /**
+   * Executes a POST request against the <code>/statements</code> endpoint. The
+   * statements which have to be added are provided through a readable stream.
+   * This method is useful for library client who wants to upload a big data set
+   * into the repository.
+   *
+   * @private
+   *
+   * @param {ReadableStream} readStream
+   * @param {string} contentType is one of RDF mime type formats,
+   *                application/x-rdftransaction' for a transaction document or
+   *                application/x-www-form-urlencoded
+   * @param {NamedNode|string} [context] optional context to restrict the
+   * operation. Will be encoded as N-Triple if it is not already one
+   * @param {string} [baseURI] optional uri against which any relative URIs
+   * found in the data would be resolved.
+   *
+   * @return {Promise<HttpResponse|Error>} a promise that will be resolved when
+   * the stream has been successfully consumed by the server
+   */
+  getUploadRequest(readStream, contentType, context, baseURI) {
+    return HttpRequestBuilder.httpPost(PATH_STATEMENTS)
+      .setData(readStream)
+      .addContentTypeHeader(contentType)
+      .setResponseType('stream')
+      .setParams({
+        baseURI,
+        context: TermConverter.toNTripleValues(context)
+      });
+  }
+
+  /**
+   * Executes a PUT request against the <code>/statements</code> endpoint. The
+   * statements which have to be updated are provided through a readable stream.
+   * This method is useful for overriding large set of statements that might be
+   * provided as a readable stream e.g. reading from file.
+   *
+   * @private
+   *
+   * @param {ReadableStream} readStream
+   * @param {string} contentType
+   * @param {NamedNode|string} context restrict the operation. Will be encoded
+   * as N-Triple if it is not already one
+   * @param {string} [baseURI] optional uri against which any relative URIs
+   * found in the data would be resolved.
+   *
+   * @return {Promise<HttpResponse|Error>} a promise that will be resolved when
+   * the stream has been successfully consumed by the server
+   */
+  getOverwriteRequest(readStream, contentType, context, baseURI) {
+    return HttpRequestBuilder.httpPut(PATH_STATEMENTS)
+      .setData(readStream)
+      .addContentTypeHeader(contentType)
+      .setResponseType('stream')
+      .setParams({
+        baseURI,
+        context: TermConverter.toNTripleValues(context)
+      });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  getServiceName() {
+    return 'UploadService';
+  }
+}
+
+
+module.exports = UploadService;

--- a/src/transaction/transactional-repository-client.js
+++ b/src/transaction/transactional-repository-client.js
@@ -230,8 +230,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    * is successful or rejected in case of failure
    */
   addQuads(quads, context, baseURI) {
-    return TermConverter.toString(quads)
-      .then((payload) => this.sendData(payload, context, baseURI));
+    return this.sendData(TermConverter.toString(quads), context, baseURI);
   }
 
   /**

--- a/src/transaction/transactional-repository-client.js
+++ b/src/transaction/transactional-repository-client.js
@@ -69,12 +69,11 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         context: TermConverter.toNTripleValues(context)
       });
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {context}),
-          'Fetched size');
-        return response.getData();
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {context}),
+        'Fetched size');
+      return response.getData();
+    });
   }
 
   /**
@@ -107,16 +106,15 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       requestBuilder.setResponseType('stream');
     }
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          subject: payload.getSubject(),
-          predicate: payload.getPredicate(),
-          object: payload.getObject(),
-          context: payload.getContext()
-        }), 'Fetched data');
-        return this.parse(response.getData(), payload.getResponseType());
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        subject: payload.getSubject(),
+        predicate: payload.getPredicate(),
+        object: payload.getObject(),
+        context: payload.getContext()
+      }), 'Fetched data');
+      return this.parse(response.getData(), payload.getResponseType());
+    });
   }
 
   /**
@@ -139,17 +137,16 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         action: 'QUERY'
       });
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          query: payload.getQuery(),
-          queryType: payload.getQueryType()
-        }), 'Queried data');
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        query: payload.getQuery(),
+        queryType: payload.getQueryType()
+      }), 'Queried data');
 
-        return this.parse(response.getData(), payload.getResponseType(), {
-          queryType: payload.getQueryType()
-        });
+      return this.parse(response.getData(), payload.getResponseType(), {
+        queryType: payload.getQueryType()
       });
+    });
   }
 
   /**
@@ -168,11 +165,10 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         action: 'UPDATE'
       });
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response,
-          {query: payload.getQuery()}), 'Performed update');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response,
+        {query: payload.getQuery()}), 'Performed update');
+    });
   }
 
   /**
@@ -264,14 +260,13 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       })
       .addContentTypeHeader(RDFMimeType.TRIG);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          data,
-          context,
-          baseURI
-        }), 'Inserted statements');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        data,
+        context,
+        baseURI
+      }), 'Inserted statements');
+    });
   }
 
   /**
@@ -294,10 +289,9 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
       })
       .addContentTypeHeader(RDFMimeType.TRIG);
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {data}), 'Deleted data');
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {data}), 'Deleted data');
+    });
   }
 
   /**
@@ -328,16 +322,15 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         infer: payload.getInference()
       });
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.logger.debug(this.getLogPayload(response, {
-          subject: payload.getSubject(),
-          predicate: payload.getPredicate(),
-          object: payload.getObject(),
-          context: payload.getContext()
-        }), 'Downloaded data');
-        return response.getData();
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.logger.debug(this.getLogPayload(response, {
+        subject: payload.getSubject(),
+        predicate: payload.getPredicate(),
+        object: payload.getObject(),
+        context: payload.getContext()
+      }), 'Downloaded data');
+      return response.getData();
+    });
   }
 
   /**
@@ -424,7 +417,7 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         baseURI
       });
 
-    return this.execute((http) => http.request(requestBuilder));
+    return this.execute(requestBuilder);
   }
 
   /**
@@ -441,14 +434,13 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
         action: 'COMMIT'
       });
 
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.active = false;
-        this.logger.debug(this.getLogPayload(response), 'Transaction commit');
-      }).catch((err) => {
-        this.active = false;
-        return Promise.reject(err);
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.active = false;
+      this.logger.debug(this.getLogPayload(response), 'Transaction commit');
+    }).catch((err) => {
+      this.active = false;
+      return Promise.reject(err);
+    });
   }
 
   /**
@@ -460,14 +452,13 @@ class TransactionalRepositoryClient extends BaseRepositoryClient {
    */
   rollback() {
     const requestBuilder = HttpRequestBuilder.httpDelete('');
-    return this.execute((http) => http.request(requestBuilder))
-      .then((response) => {
-        this.active = false;
-        this.logger.debug(this.getLogPayload(response), 'Transaction rollback');
-      }).catch((err) => {
-        this.active = false;
-        return Promise.reject(err);
-      });
+    return this.execute(requestBuilder).then((response) => {
+      this.active = false;
+      this.logger.debug(this.getLogPayload(response), 'Transaction rollback');
+    }).catch((err) => {
+      this.active = false;
+      return Promise.reject(err);
+    });
   }
 
   /**

--- a/test/model/term-converter-corner-cases.spec.js
+++ b/test/model/term-converter-corner-cases.spec.js
@@ -14,6 +14,6 @@ describe('TermConverter', () => {
         end: (callback) => callback('error')
       };
     };
-    return expect(TermConverter.toString([])).rejects.toEqual('error');
+    expect(() => TermConverter.toString([])).toThrow('error');
   });
 });

--- a/test/repository/base-repository-client-failover.spec.js
+++ b/test/repository/base-repository-client-failover.spec.js
@@ -131,8 +131,12 @@ describe('BaseRepositoryClient', () => {
     });
 
     it('should reject if it cannot properly execute requests', () => {
-      // Not providing a consumer function should cause the client blow and reject
-      expect(repositoryClient.execute()).rejects.toEqual(Error);
+      const err = new Error('Cannot request');
+      let httpClient1 = repositoryClient.httpClients[0];
+      httpClient1.request = () => {
+        throw err;
+      };
+      return expect(repositoryClient.execute()).rejects.toEqual(err);
     });
   });
 

--- a/test/repository/base-repository-client-failover.spec.js
+++ b/test/repository/base-repository-client-failover.spec.js
@@ -1,6 +1,7 @@
 const HttpClient = require('http/http-client');
 const RepositoryClientConfig = require('repository/repository-client-config');
 const BaseRepositoryClient = require('repository/base-repository-client');
+const HttpRequestBuilder = require('http/http-request-builder');
 const httpClientStub = require('../http/http-client.stub');
 
 jest.mock('http/http-client');
@@ -9,6 +10,7 @@ describe('BaseRepositoryClient', () => {
 
   let repoClientConfig;
   let repositoryClient;
+  let requestBuilder;
 
   describe('Automatic failover - retrying with different repo endpoint', () => {
     beforeEach(() => {
@@ -24,6 +26,7 @@ describe('BaseRepositoryClient', () => {
       HttpClient.mockImplementation(() => httpClientStub());
 
       repositoryClient = new TestRepositoryClient(repoClientConfig);
+      requestBuilder = HttpRequestBuilder.httpGet('/service');
     });
 
     test('should automatically switch to another repository endpoint if the status is allowed for retry', () => {
@@ -37,7 +40,7 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClient(httpClient3, 200);
 
-      return repositoryClient.execute((client) => client.request('url')).then(() => {
+      return repositoryClient.execute(requestBuilder).then(() => {
         expect(httpClient1.request).toHaveBeenCalledTimes(1);
         expect(httpClient2.request).toHaveBeenCalledTimes(1);
         expect(httpClient3.request).toHaveBeenCalledTimes(1);
@@ -54,7 +57,7 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClient(httpClient3, 503);
 
-      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+      return repositoryClient.execute(requestBuilder).catch(() => {
         expect(httpClient1.request).toHaveBeenCalledTimes(1);
         expect(httpClient2.request).toHaveBeenCalledTimes(1);
         expect(httpClient3.request).toHaveBeenCalledTimes(1);
@@ -72,7 +75,7 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClient(httpClient3, 200);
 
-      return repositoryClient.execute((client) => client.request('url')).then(() => {
+      return repositoryClient.execute(requestBuilder).then(() => {
         expect(httpClient1.request).toHaveBeenCalledTimes(1);
         expect(httpClient2.request).toHaveBeenCalledTimes(1);
         expect(httpClient3.request).toHaveBeenCalledTimes(1);
@@ -90,7 +93,7 @@ describe('BaseRepositoryClient', () => {
       let httpClient3 = repositoryClient.httpClients[2];
       stubHttpClientWithoutResponse(httpClient3);
 
-      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+      return repositoryClient.execute(requestBuilder).catch(() => {
         expect(httpClient1.request).toHaveBeenCalledTimes(1);
         expect(httpClient2.request).toHaveBeenCalledTimes(1);
         expect(httpClient3.request).toHaveBeenCalledTimes(1);
@@ -105,7 +108,7 @@ describe('BaseRepositoryClient', () => {
       let httpClient2 = repositoryClient.httpClients[1];
       let httpClient3 = repositoryClient.httpClients[2];
 
-      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+      return repositoryClient.execute(requestBuilder).catch(() => {
         expect(httpClient1.request).toHaveBeenCalledTimes(1);
         expect(httpClient2.request).toHaveBeenCalledTimes(0);
         expect(httpClient3.request).toHaveBeenCalledTimes(0);
@@ -120,7 +123,7 @@ describe('BaseRepositoryClient', () => {
       let httpClient2 = repositoryClient.httpClients[1];
       let httpClient3 = repositoryClient.httpClients[2];
 
-      return repositoryClient.execute((client) => client.request('url')).catch(() => {
+      return repositoryClient.execute(requestBuilder).catch(() => {
         expect(httpClient1.request).toHaveBeenCalledTimes(1);
         expect(httpClient2.request).toHaveBeenCalledTimes(0);
         expect(httpClient3.request).toHaveBeenCalledTimes(0);

--- a/test/repository/rdf-repository-client-adding-data.spec.js
+++ b/test/repository/rdf-repository-client-adding-data.spec.js
@@ -203,8 +203,8 @@ describe('RDFRepositoryClient - adding data', () => {
   describe('addQuads(quads)', () => {
     test('should throw error when no data is provided', () => {
       const quads = [];
-      return expect(rdfRepositoryClient.addQuads(quads))
-        .rejects.toEqual(Error('Turtle/trig data is required when adding statements'));
+      return expect(() => rdfRepositoryClient.addQuads(quads))
+        .toThrow(Error('Turtle/trig data is required when adding statements'));
     });
 
     test('should convert the quads to turtle and send a request', () => {

--- a/test/repository/rdf-repository-client-transactions.spec.js
+++ b/test/repository/rdf-repository-client-transactions.spec.js
@@ -470,30 +470,6 @@ describe('RDFRepositoryClient - transactions', () => {
       });
     });
 
-    describe('sendData()', () => {
-      test('should add data', () => {
-        return transaction.sendData(data).then(() => {
-          expectInsertedData(data, undefined, undefined);
-        });
-      });
-
-      test('should require data when adding', () => {
-        expect(() => transaction.sendData()).toThrow();
-        expect(() => transaction.sendData('')).toThrow();
-        expect(() => transaction.sendData('  ')).toThrow();
-        expect(transactionHttpRequest).toHaveBeenCalledTimes(0);
-      });
-
-      test('should reject if the transaction cannot add data', () => {
-        transactionHttpRequest.mockRejectedValue('Error during add');
-        return expect(transaction.sendData(data)).rejects.toEqual('Error during add');
-      });
-
-      test('should resolve to empty response (HTTP 204)', () => {
-        return expect(transaction.sendData(data)).resolves.toEqual();
-      });
-    });
-
     function expectInsertedData(expectedData, expectedContext, expectedBaseURI) {
       const expectedRequest = HttpRequestBuilder.httpPut('')
         .setData(expectedData)

--- a/test/server/server-client.test.js
+++ b/test/server/server-client.test.js
@@ -113,10 +113,7 @@ describe('ServerClient', () => {
       const repositoryClientConfig = new RepositoryClientConfig().setEndpoints(['endpoint']);
       const expected = new RDFRepositoryClient(repositoryClientConfig);
       return server.getRepository('automotive', repositoryClientConfig).then((actual) => {
-        // Omit axios instances, they fail the deep equal check
-        actual.httpClients.forEach((client) => delete client.axios);
-        expected.httpClients.forEach((client) => delete client.axios);
-        expect(actual).toEqual(expected);
+        expect(actual.repositoryClientConfig).toEqual(expected.repositoryClientConfig);
       });
     });
   });

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -1,0 +1,15 @@
+const Service = require('service/service');
+
+/*
+ * Testing corner cases in the base Service class.
+ */
+describe('Service', () => {
+  it('should require to implement getServiceName()', () => {
+    expect(() => new Service(() => {})).toThrow(Error('Must be overridden!'));
+    expect(() => new InvalidService(() => {})).toThrow(Error('Must be overridden!'));
+  });
+});
+
+class InvalidService extends Service {
+  // Not implementing abstract methods.
+}


### PR DESCRIPTION
Introduced `ServiceRequest` wrapper that carries the HTTP request builder along with the HTTP request executor. This allows to mutate params before executing requests.

Extracted `RdfRepositoryClient` logic to separate services which produce `ServiceRequest`. Reused the services in the `TransactionalRepositoryClient` where the service request is mutated to HTTP PUT along with the correct action parameter.

Additional changes:

- Moved service path segments to service-paths.js.
- Changed TermConverter to convert quads to string synchronously.
- Refactored base repository client to accept the request builder instead of consumer function. The consumer function was needed to be able to send the request to get/post/put/delete but now there is only `.request()`. This greatly simplifies the clients.

Resolves #27