### PR TITLE
Initialize milestone 1.2.0 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Javascript client library supporting GraphDB and RDF4J REST API.",
   "author": {
     "name": "\"Sirma AI\" JSC, trading as Ontotext",

--- a/test-e2e/docker-compose.yml
+++ b/test-e2e/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
 
   graphdb:
-    image: docker-registry.ontotext.com/graphdb-free:8.11.0-free
+    image: docker-registry.ontotext.com/graphdb-free:9.0.0-RC2-free
     container_name: graphdb
     # This will allow GraphDB to access host resources (locally running or in Travis)
     # Needed to load data from localhost (see queries.spec.js)

--- a/test-e2e/package-lock.json
+++ b/test-e2e/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb-acceptance-tests",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-e2e/package.json
+++ b/test-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb-acceptance-tests",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "\"Sirma AI\" JSC, trading as Ontotext",
     "url": "https://www.ontotext.com/"


### PR DESCRIPTION
Changes
- Bumped module version to 1.2.0 for the milestone
- Updated to GraphDB Free version 9.0.0 RC2 for the acceptance tests