### PR TITLE
Updated Travis config to allow PR builds to feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ node_js:
   - 10
   - 12
 
-# Build only commits on master and release tags preventing double builds for PRs
-# See https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests
-branches:
-  only:
-    - master
-    - /v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
+# Trigger build only when one of the following conditions is met
+if: type = pull_request OR branch = master OR tag IS present
 
 cache: npm
 


### PR DESCRIPTION
The previous restriction allowed builds only when the target branch = master or a tag with specific name pushed.

Now every tag would be allowed too.