### PR TITLE
Update graphdb version for e2e tests

### DIFF
--- a/test-e2e/docker-compose.yml
+++ b/test-e2e/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
 
   graphdb:
-    image: docker-registry.ontotext.com/graphdb-free:8.11.0-free
+    image: docker-registry.ontotext.com/graphdb-free:9.1.1-free
     container_name: graphdb
     # This will allow GraphDB to access host resources (locally running or in Travis)
     # Needed to load data from localhost (see queries.spec.js)


### PR DESCRIPTION
Update to graphdb-free:9.1.1-free