### PR TITLE
ci(release): Prevents throwing an error when npm version is same

### DIFF
--- a/JenkinsfileRelease
+++ b/JenkinsfileRelease
@@ -50,9 +50,9 @@ pipeline {
         sh "git checkout ${branch}"
 
         // Change versions
-        sh "npm version --git-tag-version=false ${ReleaseVersion}"
+        sh "npm version --git-tag-version=false --allow-same-version=true ${ReleaseVersion}"
         dir("test-e2e/") {
-          sh "npm version --git-tag-version=false ${ReleaseVersion}"
+          sh "npm version --git-tag-version=false --allow-same-version=true ${ReleaseVersion}"
         }
 
         // Install


### PR DESCRIPTION
Prevents throwing an error when npm version is used to set the new
version to the same value as the current version when setting it
manually in package.json