### PR TITLE
Add Slack notification to release pipeline

### DIFF
--- a/release.Jenkinsfile
+++ b/release.Jenkinsfile
@@ -24,6 +24,18 @@ pipeline {
     booleanParam name: 'PRE_RELEASE',
            description: 'This is a pre-release. Will not publish to npm if selected',
            defaultValue: false
+
+    booleanParam(
+      name: 'NOTIFY_SLACK',
+      defaultValue: false,
+      description: 'Send Slack notification after successful build'
+    )
+
+    string(
+      name: 'SLACK_CHANNEL',
+      defaultValue: '#frontend-notifications',
+      description: 'Slack channel for notification (only used if checkbox above is selected)'
+    )
   }
 
   agent {
@@ -116,6 +128,15 @@ pipeline {
             def result = postRelease(composeReleaseMessage(gitMessages), "$GIT_TOKEN")
             echo result
           }
+        }
+      }
+
+      // Optional Slack notification if enabled and channel is provided
+      if (params.NOTIFY_SLACK && params.SLACK_CHANNEL?.trim()) {
+        try {
+          slack.notifyResult(channel: params.SLACK_CHANNEL, color:'good', message:"Released graphdb-workbench v${params.RELEASE_VERSION}")
+        } catch (e) {
+          echo "Slack notification failed: ${e.getMessage()}"
         }
       }
     }


### PR DESCRIPTION
## What
Added parameters to enable Slack notifications after a successful build in the release pipeline.

## Why
This enhancement allows team members to receive immediate notifications on Slack, improving communication and awareness of build statuses.

## How
- Introduced a boolean parameter `NOTIFY_SLACK` to toggle notifications.
- Added a string parameter `SLACK_CHANNEL` to specify the channel for notifications.
- Implemented logic to send a notification to Slack if the parameters are set and the build is successful.

## Testing
n/a

## Checklist
- [x] Branch name
- [x] Target branch
- [x] Commit messages
- [x] Squash commits
- [x] MR name
- [x] MR Description
- [x] Tests
