### PR TITLE
Fix package-lock optional fsevents entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4043,6 +4043,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",


### PR DESCRIPTION
## Summary
- refresh `package-lock.json` so the optional `fsevents@2.3.3` package entry is present
- keeps `npm ci` in sync with the committed package manifest/lockfile

## Validation
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test -- --runInBand`

Fixes #235